### PR TITLE
Feature/vvalenti/gocart2g to gmi connectivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Capability for AERO_PROVIDER=GMICHEM
 - Capability for AERO_PROVIDER=CARMA (uses GMICHEM right now)
+- Connectivity from GOCART2G to GMI chem
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+
+### Added
+
+- Capability for AERO_PROVIDER=GMICHEM
+- Capability for AERO_PROVIDER=CARMA (uses GMICHEM right now)
+
+### Removed
+
+- Code that might have eventually run GOCART-like aerosols from within the GMI framework (note: doubtful this ever worked and would take significant effort to get working IMHO)
+
+
 ## [1.0.0] - 2023-01-18
 
 ### Added

--- a/GMI_GridComp/GMI_ExtData.rc
+++ b/GMI_GridComp/GMI_ExtData.rc
@@ -79,23 +79,22 @@ MEGAN_LAI_009      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_009	 ExtData/g5
 MEGAN_LAI_010      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_010	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
 MEGAN_LAI_011      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_011	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
 MEGAN_LAI_012      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_012	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-BC1                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  BC1		 /dev/null
-BC2                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  BC2		 /dev/null
-OC1                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  OC1		 /dev/null
-OC2                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  OC2		 /dev/null
-SS1                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SS1		 /dev/null
-SS2                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SS2		 /dev/null
-SS3                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SS3		 /dev/null
-SS4                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SS4		 /dev/null
-SO4                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SO4		 /dev/null
-SO4v                'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SO4v		 /dev/null
-MDUST1              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST1		 /dev/null
-MDUST2              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST2		 /dev/null
-MDUST3              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST3		 /dev/null
-MDUST4              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST4		 /dev/null
-MDUST5              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST5		 /dev/null
-MDUST6              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST6		 /dev/null
-MDUST7              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST7		 /dev/null
+BCphobic           'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  BCPHOBIC          /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+BCphilic           'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  BCPHILIC          /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+OCphobic           'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  OCPHOBIC          /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+OCphilic           'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  OCPHILIC          /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+ss001              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS001             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+ss002              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS002             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+ss003              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS003             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+ss004              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS004             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+ss005              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS005             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+SO4                'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SO4               /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+SO4v               'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SO4v              /dev/null
+du001              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU001             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+du002              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU002             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+du003              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU003             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+du004              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU004             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+du005              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU005             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
 # -----------|--------------|-----|---|----------------------|--------|-------|-----------------|----------------------   
 %%
 

--- a/GMI_GridComp/GMI_ExtData.yaml
+++ b/GMI_GridComp/GMI_ExtData.yaml
@@ -35,6 +35,8 @@ Collections:
     template: ExtData/CMIP6/L72/SAD/sad_wt_CMIP6_288x181x72_%y4.nc
   GMI_veg_fraction_x720_y360_t12_2008.nc:
     template: ExtData/g5chem/sfc/LAI/veg_fraction_x720_y360_t12_2008.nc
+  GMI_aerodust_file:
+    template: /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
 
 Samplings:
   GMI_sample_0:
@@ -54,6 +56,68 @@ Samplings:
     extrapolation: clim
 
 Exports:
+  BCphobic:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: BCPHOBIC
+  BCphilic:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: BCPHILIC
+  OCphobic:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: OCPHOBIC
+  OCphilic:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: OCPHILIC
+  SO4:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: SO4
+  SO4v:
+    collection: /dev/null
+  ss001:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: SS001
+  ss002:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: SS002
+  ss003:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: SS003
+  ss004:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: SS004
+  ss005:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: SS005
+  du001:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: DU001
+  du002:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: DU002
+  du003:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: DU003
+  du004:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: DU004
+  du005:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: DU005
   ACET_FIXED:
     collection: GMI_acetone_fixed_GMI.x288_y181_z72_t12.2001.nc
     sample: GMI_sample_0
@@ -77,10 +141,6 @@ Exports:
     regrid: CONSERVE
     sample: GMI_sample_1
     variable: ALK4_ff
-  BC1:
-    collection: /dev/null
-  BC2:
-    collection: /dev/null
   C2H6_biof:
     collection: /dev/null
   C2H6_biom:
@@ -177,20 +237,6 @@ Exports:
     collection: GMI_lai_x720_y360_v72_t12_2008.nc
     sample: GMI_sample_0
     variable: LAI_FRAC
-  MDUST1:
-    collection: /dev/null
-  MDUST2:
-    collection: /dev/null
-  MDUST3:
-    collection: /dev/null
-  MDUST4:
-    collection: /dev/null
-  MDUST5:
-    collection: /dev/null
-  MDUST6:
-    collection: /dev/null
-  MDUST7:
-    collection: /dev/null
   MEGAN_ISOP:
     collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
     regrid: CONSERVE
@@ -309,10 +355,6 @@ Exports:
     collection: /dev/null
   NO_ship:
     collection: /dev/null
-  OC1:
-    collection: /dev/null
-  OC2:
-    collection: /dev/null
   OCS_CLIMO:
     collection: GMI_OCS_vmr.x360_y181_z72.t12.2016.nc4
     sample: GMI_sample_0
@@ -363,10 +405,6 @@ Exports:
     regrid: CONSERVE
     sample: GMI_sample_1
     variable: SO2_shipping
-  SO4:
-    collection: /dev/null
-  SO4v:
-    collection: /dev/null
   SOILFERT:
     collection: GMI_fertilizer_GMI.x288_y181_t12.2006.nc
     regrid: CONSERVE
@@ -376,17 +414,7 @@ Exports:
     collection: GMI_precipitation_GMI.x288_y181_t12.2006.nc
     sample: GMI_sample_0
     variable: soilPrecip
-  SS1:
-    collection: /dev/null
-  SS2:
-    collection: /dev/null
-  SS3:
-    collection: /dev/null
-  SS4:
-    collection: /dev/null
   VEG_FRAC:
     collection: GMI_veg_fraction_x720_y360_t12_2008.nc
     sample: GMI_sample_0
     variable: VEG_FRAC
-
-

--- a/GMI_GridComp/GmiChemistry/AerosolDust/GmiAerDustODSA_mod.F90
+++ b/GMI_GridComp/GmiChemistry/AerosolDust/GmiAerDustODSA_mod.F90
@@ -561,7 +561,7 @@
 ! !LOCAL VARIABLES:
       REAL*8       :: MSDENS(NSADdust)
 
-      integer      :: i, j , k, l, n, r
+      integer      :: i, j, k, l, n, r
 !
 ! !REVISION HISTORY:
 !   February2005, Jules Kouatchou (Jules.Kouatchou.1@gsfc.nasa.gov)

--- a/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_Registry.rc
+++ b/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_Registry.rc
@@ -142,23 +142,22 @@
   MEGAN_LAI_010      |  cm cm-2        | xy  |   |    |   |   |     |	   |  x | AVHRR_leaf_area_index_oct_2000
   MEGAN_LAI_011      |  cm cm-2        | xy  |   |    |   |   |     |	   |  x | AVHRR_leaf_area_index_nov_2000
   MEGAN_LAI_012      |  cm cm-2        | xy  |   |    |   |   |     |	   |  x | AVHRR_leaf_area_index_dec_2000
-  BC1                |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophobic_black_carbon
-  BC2                |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophilic_black_carbon
-  OC1                |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophobic_organic_carbon
-  OC2                |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophilic_organic_carbon
-  SS1                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
-  SS2                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
-  SS3                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
-  SS4                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  BCphobic           |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophobic_black_carbon
+  BCphilic           |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophilic_black_carbon
+  OCphobic           |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophobic_organic_carbon
+  OCphilic           |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophilic_organic_carbon
+  ss001              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  ss002              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  ss003              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  ss004              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  ss005              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
   SO4                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sulfate
   SO4v               |  kg m-3         | xyz | C |    |   |   |     |      |  x | sulfate_from_volcanos
-  MDUST1             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST2             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST3             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST4             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST5             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST6             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST7             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du001              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du002              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du003              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du004              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du005              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
 # -------------------|-----------------|-----|---|----|---|---|-----|------|--------------------------
 </ImportSpec>
 
@@ -171,19 +170,21 @@
 #  Short	    |		     |     | V |Item|Intervl| Sub |	     Long
 #  Name 	    |   Units	     | Dim |Loc|Type| R | A |Tiles|	     Name
 # ------------------|----------------|-----|---|----|---|---|-----|---------------------------------
-  GMICHEM::BCphobic | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_hydrophobic_black_carbon_from_GMICHEM
-  GMICHEM::BCphilic | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_hydrophylic_black_carbon_from_GMICHEM
-  GMICHEM::du001    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_dust_bin_1_from_GMICHEM
-  GMICHEM::du002    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_dust_bin_2_from_GMICHEM
-  GMICHEM::du003    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_dust_bin_3_from_GMICHEM
-  GMICHEM::du004    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_dust_bin_4_from_GMICHEM
-  GMICHEM::OCphobic | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_hydrophobic_organic_carbon_from_GMICHEM
-  GMICHEM::OCphilic | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_hydrophylic_organic_carbon_from_GMICHEM
-  GMICHEM::ss001    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sea_salt_bin_1_from_GMICHEM
-  GMICHEM::ss003    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sea_salt_bin_3_from_GMICHEM
-  GMICHEM::ss004    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sea_salt_bin_4_from_GMICHEM
-  GMICHEM::ss005    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sea_salt_bin_5_from_GMICHEM
-  GMICHEM::SO4      | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sulfate_from_GMICHEM
+  BCphobic | kg kg-1        | xyz | C |    |   |   |     | prescribed_hydrophobic_black_carbon_from_GMICHEM
+  BCphilic | kg kg-1        | xyz | C |    |   |   |     | prescribed_hydrophylic_black_carbon_from_GMICHEM
+  du001    | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_1_from_GMICHEM
+  du002    | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_2_from_GMICHEM
+  du003    | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_3_from_GMICHEM
+  du004    | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_4_from_GMICHEM
+  du005    | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_4_from_GMICHEM
+  OCphobic | kg kg-1        | xyz | C |    |   |   |     | prescribed_hydrophobic_organic_carbon_from_GMICHEM
+  OCphilic | kg kg-1        | xyz | C |    |   |   |     | prescribed_hydrophylic_organic_carbon_from_GMICHEM
+  ss001    | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_1_from_GMICHEM
+  ss002    | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_1_from_GMICHEM
+  ss003    | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_3_from_GMICHEM
+  ss004    | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_4_from_GMICHEM
+  ss005    | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_5_from_GMICHEM
+  SO4      | kg kg-1        | xyz | C |    |   |   |     | prescribed_sulfate_from_GMICHEM
   REFFICE  	    | cm  	     | xyz | C |    |	|   |	  | ice_aerosol_effective_radius
   REFFSTS 	    | cm  	     | xyz | C |    |	|   |	  | STS_aerosol_effective_radius
   VFALL   	    | cm s-1	     | xyz | C |    |	|   |	  | effective_aerosol_fall_velocity

--- a/GMI_GridComp/GmiChemistry/StratTrop_Orig/GMI_Registry.rc
+++ b/GMI_GridComp/GmiChemistry/StratTrop_Orig/GMI_Registry.rc
@@ -132,23 +132,22 @@
   MEGAN_LAI_010      |  cm cm-2        | xy  |   |    |   |   |     |	   |  x | AVHRR_leaf_area_index_oct_2000
   MEGAN_LAI_011      |  cm cm-2        | xy  |   |    |   |   |     |	   |  x | AVHRR_leaf_area_index_nov_2000
   MEGAN_LAI_012      |  cm cm-2        | xy  |   |    |   |   |     |	   |  x | AVHRR_leaf_area_index_dec_2000
-  BC1                |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophobic_black_carbon
-  BC2                |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophilic_black_carbon
-  OC1                |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophobic_organic_carbon
-  OC2                |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophilic_organic_carbon
-  SS1                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
-  SS2                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
-  SS3                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
-  SS4                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  BCphobic           |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophobic_black_carbon
+  BCphilic           |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophilic_black_carbon
+  OCphobic           |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophobic_organic_carbon
+  OCphilic           |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophilic_organic_carbon
+  ss001              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  ss002              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  ss003              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  ss004              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  ss005              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
   SO4                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sulfate
   SO4v               |  kg m-3         | xyz | C |    |   |   |     |      |  x | sulfate_from_volcanos
-  MDUST1             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST2             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST3             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST4             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST5             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST6             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST7             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du001              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du002              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du003              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du004              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du005              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
 # -------------------|-----------------|-----|---|----|---|---|-----|------|--------------------------
 </ImportSpec>
 
@@ -161,19 +160,21 @@
 #  Short	    |		     |     | V |Item|Intervl| Sub |	     Long
 #  Name 	    |   Units	     | Dim |Loc|Type| R | A |Tiles|	     Name
 # ------------------|----------------|-----|---|----|---|---|-----|---------------------------------
-  GMICHEM::BCphobic | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_hydrophobic_black_carbon_from_GMICHEM
-  GMICHEM::BCphilic | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_hydrophylic_black_carbon_from_GMICHEM
-  GMICHEM::du001    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_dust_bin_1_from_GMICHEM
-  GMICHEM::du002    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_dust_bin_2_from_GMICHEM
-  GMICHEM::du003    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_dust_bin_3_from_GMICHEM
-  GMICHEM::du004    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_dust_bin_4_from_GMICHEM
-  GMICHEM::OCphobic | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_hydrophobic_organic_carbon_from_GMICHEM
-  GMICHEM::OCphilic | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_hydrophylic_organic_carbon_from_GMICHEM
-  GMICHEM::ss001    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sea_salt_bin_1_from_GMICHEM
-  GMICHEM::ss003    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sea_salt_bin_3_from_GMICHEM
-  GMICHEM::ss004    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sea_salt_bin_4_from_GMICHEM
-  GMICHEM::ss005    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sea_salt_bin_5_from_GMICHEM
-  GMICHEM::SO4      | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sulfate_from_GMICHEM
+  BCphobic          | kg kg-1        | xyz | C |    |   |   |     | prescribed_hydrophobic_black_carbon_from_GMICHEM
+  BCphilic          | kg kg-1        | xyz | C |    |   |   |     | prescribed_hydrophylic_black_carbon_from_GMICHEM
+  du001             | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_1_from_GMICHEM
+  du002             | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_2_from_GMICHEM
+  du003             | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_3_from_GMICHEM
+  du004             | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_4_from_GMICHEM
+  du005             | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_4_from_GMICHEM
+  OCphobic          | kg kg-1        | xyz | C |    |   |   |     | prescribed_hydrophobic_organic_carbon_from_GMICHEM
+  OCphilic          | kg kg-1        | xyz | C |    |   |   |     | prescribed_hydrophylic_organic_carbon_from_GMICHEM
+  ss001             | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_1_from_GMICHEM
+  ss002             | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_1_from_GMICHEM
+  ss003             | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_3_from_GMICHEM
+  ss004             | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_4_from_GMICHEM
+  ss005             | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_5_from_GMICHEM
+  SO4               | kg kg-1        | xyz | C |    |   |   |     | prescribed_sulfate_from_GMICHEM
   REFFICE  	    | cm  	     | xyz | C |    |	|   |	  | ice_aerosol_effective_radius
   REFFSTS 	    | cm  	     | xyz | C |    |	|   |	  | STS_aerosol_effective_radius
   VFALL   	    | cm s-1	     | xyz | C |    |	|   |	  | effective_aerosol_fall_velocity

--- a/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
@@ -137,8 +137,7 @@
      LOGICAL :: pr_diag
      LOGICAL :: do_drydep
      LOGICAL :: do_wetdep
-     LOGICAL :: do_emission             
-     LOGICAL :: do_aerocom             
+     LOGICAL :: do_emission            
      LOGICAL :: pr_const
      LOGICAL :: do_synoz
      LOGICAL :: do_gcr
@@ -399,10 +398,6 @@
 
     call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_const, &
               label="pr_const:", default=.false., rc=STATUS )
-    VERIFY_(STATUS)
-
-    call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_aerocom, &
-              label="do_aerocom:", default=.false., rc=STATUS )
     VERIFY_(STATUS)
 
     call ESMF_ConfigGetAttribute(gmiConfigFile, self%metdata_name_org, &
@@ -815,7 +810,7 @@
    INTEGER,                 INTENT(IN)    :: nymd, nhms  ! time
    REAL,                    INTENT(IN)    :: tdt         ! chemical timestep (secs)
    LOGICAL,                 INTENT(IN)    :: mixPBL      ! whether to explicitly distribute
-                                                         ! aerosol emissions within the PBL
+                                                         ! emissions within the PBL
 ! !OUTPUT PARAMETERS:
 
    INTEGER,                 INTENT(OUT)   :: rc          ! Error return code:
@@ -1184,7 +1179,7 @@
                      ISSLT3, ISSLT4, IFSO2, INSO2, INDMS, IAN, IMGAS, INO,     &
                      IC5H8, INO, ICO, IC3H6, IHNO3, IO3, NSP, diffusePAR,      &
                      directPAR, T_15_AVG, self%met_opt, self%chem_opt,         &
-                     self%trans_opt, self%do_aerocom, self%do_drydep,          &
+                     self%trans_opt, self%do_drydep,          &
                      self%pr_diag, self%pr_const, self%pr_surf_emiss,          &
                      self%pr_emiss_3d, self%metdata_name_org,                  &
                      self%metdata_name_model, tdt, mixPBL, light_NO_prod)

--- a/GMI_GridComp/GmiEmission/llnl/emiss_llnl.F90
+++ b/GMI_GridComp/GmiEmission/llnl/emiss_llnl.F90
@@ -13,13 +13,6 @@
 !   Add_Emiss_Llnl
 !
 ! HISTORY
-!   - December 8, 2005 * Bigyani Das
-!     Changes are made for the aerocom run which are controlled by 2 parameters
-!     do_aerocom and do_dust_emiss to add dust and sea salt emissions in 
-!     the model's  1st level. Originally sea salt emissions 
-!     were added in the emission fields with carbon emission, 
-!     now it is added with dust (dust and sea salt emissions are now 
-!     in the same files, before sea salt emissions were with carbon).
 !=============================================================================
 
 
@@ -49,26 +42,20 @@
 !   const          : species concentration, known at zone centers
 !                    (mixing ratio)
 !   emiss          : array of emissions (kg/s)
-!   emiss_dust     : tbd
-!   emiss_aero     :
 !   pbl            :
 !-----------------------------------------------------------------------------
 
       subroutine Add_Emiss_Llnl  &
-     &  (do_aerocom, pr_surf_emiss, pr_emiss_3d, mcor, surf_emiss_out, emiss_3d_out,  &
-     &   mass, concentration, emissionArray, emiss_dust, emiss_aero_t, emiss_aero, pbl, &
+     &  (pr_surf_emiss, pr_emiss_3d, mcor, surf_emiss_out, emiss_3d_out,  &
+     &   mass, concentration, emissionArray, pbl, &
      &   gridBoxHeight, IBOC, IBBC, INOC, IFOC, IFBC, ISSLT1, ISSLT2, ISSLT3, ISSLT4, &
-     &   IFSO2, INSO2, INDMS, pr_diag, loc_proc, chem_opt, trans_opt, emiss_aero_opt, &
-     &   emiss_dust_opt, do_semiss_inchem, emiss_map, emiss_map_dust, emiss_map_aero, &
-     &   emissionSpeciesLayers, ndust, naero, nymd, mw, tdt, emiss_timpyr, num_emiss, &
+     &   IFSO2, INSO2, INDMS, pr_diag, loc_proc, chem_opt, trans_opt, &
+     &   do_semiss_inchem, emiss_map, &
+     &   emissionSpeciesLayers, nymd, mw, tdt, emiss_timpyr, num_emiss, &
      &   i1, i2, ju1, j2, k1, k2, ilo, ihi, julo, jhi, num_species, mixPBL)
 
       use GmiArrayBundlePointer_mod, only : t_GmiArrayBundle
       use GmiTimeControl_mod  , only : GmiSplitDateTime
-      use GmiSeaSaltMethod_mod, only : SourceSeaSalt
-      use GmiSeaSaltMethod_mod, only : srcEmissSeaSalt
-      use GmiDustMethod_mod   , only : SourceDust
-      use GmiDustMethod_mod   , only : srcEmissDust
 
       implicit none
 
@@ -85,30 +72,25 @@
       integer, intent(in   ) :: loc_proc
       integer, intent(in   ) :: i1, i2, ju1, j2, k1, k2, ilo, ihi, julo, jhi
       integer, intent(in   ) :: num_species, emiss_timpyr, num_emiss
-      integer, intent(in   ) :: ndust, naero, nymd
+      integer, intent(in   ) :: nymd
       real*8 , intent(in   ) :: mw(num_species)
       real*8 , intent(in   ) :: tdt
-      integer, intent(in   ) :: chem_opt, trans_opt, emiss_aero_opt, emiss_dust_opt
-      integer, intent(in   ) :: emiss_map(num_species), emiss_map_dust(num_species)
-      integer, intent(in   ) :: emiss_map_aero(num_species)
+      integer, intent(in   ) :: chem_opt, trans_opt
+      integer, intent(in   ) :: emiss_map(num_species)
       logical, intent(in   ) :: do_semiss_inchem
-      logical, intent(in   ) :: do_aerocom
       logical, intent(in   ) :: pr_surf_emiss, pr_emiss_3d
       real*8 , intent(in   ) :: mcor (i1:i2, ju1:j2)
       real*8 , intent(inout) :: surf_emiss_out(i1:i2, ju1:j2, num_species)
       real*8 , intent(inout) :: emiss_3d_out(i1:i2, ju1:j2, k1:k2, num_species)
       real*8 , intent(in   ) :: mass (i1:i2, ju1:j2, k1:k2)
 !      real*8 , intent(in   ) :: emiss(i1:i2, ju1:j2, k1:k2, num_emiss)
-      real*8 , intent(inout) :: emiss_dust(i1:i2, ju1:j2, ndust)
-      real*8 , intent(in   ) :: emiss_aero_t(i1:i2, ju1:j2, naero, emiss_timpyr)
-      real*8 , intent(out  ) :: emiss_aero(i1:i2, ju1:j2, naero)
       real*8 , intent(in   ) :: pbl (i1:i2, ju1:j2)
       real*8 , intent(in   ) :: gridBoxHeight(i1:i2, ju1:j2, k1:k2)
       type (t_GmiArrayBundle), intent(inout) :: concentration(num_species)
       type (t_GmiArrayBundle), intent(inout) :: emissionArray(num_emiss  )
       integer, intent(in   ) :: emissionSpeciesLayers(num_species)
       logical, intent(in   ) :: mixPBL    ! whether to explicitly distribute
-                                          ! aerosol emissions within the PBL
+                                          ! emissions within the PBL
 
 !     ----------------------
 !     Variable declarations.
@@ -298,7 +280,6 @@
 
           END IF
 
-
 !                                ============
           if (inum == num_emiss) exit SPCLOOP
 !                                ============
@@ -308,130 +289,6 @@
 !     ==============
       end do SPCLOOP
 !     ==============
-
-!     ----------------------
-!     GMI or GOCART aerosols
-!     ----------------------
-
-      if (emiss_timpyr == MONTHS_PER_YEAR) then
-        call GmiSplitDateTime  (nymd, idumyear, month, idumday)
-        it = month
-      else
-        it = 1
-      end if
-
-      if (emiss_aero_opt == 1) then                        ! GMI    aerosol emissions
-         emiss_aero(i1:i2,ju1:j2,1:naero) = emiss_aero_t(i1:i2,ju1:j2,1:naero,it)
-      elseif (emiss_aero_opt == 2) then                    ! GOCART aerosol emissions
-         emiss_aero(i1:i2,ju1:j2,1:5)     = emiss_aero_t(i1:i2,ju1:j2,1:5,it)
-      end if
-
-!     =====================================================
-      if ((emiss_aero_opt /= 0) .or. (emiss_dust_opt /= 0)) then
-!     =====================================================
-
-
-!       -------------------------------------------------------------------
-!       Add dust emission and other aerosols to some lowest vertical levels
-!       (emitted uniformly below the PBL).
-!       -------------------------------------------------------------------
-
-!       ----------------------------------------------------------------
-!       Add dust and aerosol emissions (kg/s) to concentrations; unit of
-!       aerosol and dust concentrations is kg/(kg air).
-!       ----------------------------------------------------------------
-
-!!!!! GOCART Source for dust
-        if (emiss_dust_opt == 2) then
-           call SourceDust (mcor, tdt, nymd, i1, i2, ju1, j2, k1, k2)
-           emiss_dust(i1:i2,ju1:j2,1:ndust) = srcEmissDust(i1:i2,ju1:j2,1:ndust)
-        end if
-!!!!! GOCART Source for sea salt
-        if (emiss_aero_opt == 2) then
-           call SourceSeaSalt (mcor, tdt, nymd, i1, i2, ju1, j2, k1, k2)
-           emiss_aero(i1:i2,ju1:j2,6:naero) = srcEmissSeaSalt(i1:i2,ju1:j2,1:4)
-        end if
-!!!!!
-
-        do ij = ju1, j2
-          do il = i1, i2
-
-            IKLOOP2: do ik = k1, k2
-
-              if ((za(il,ij,ik) > pbl(il,ij)) .and. (ik /= k1)) then
-!               ============
-                exit IKLOOP2
-!               ============
-              end if
-
-!             -----
-!             Dust.
-!             -----
-
-              if (emiss_dust_opt /= 0) then
-                do icx = 1, ndust
-
-                  ic = emiss_map_dust(icx)
-
-! Bigyani's correction
-!                 if (mass_pbl(il,ij) .le. 1.e-20)then
-!                    mass_pbl(il,ij) = 1.e-10
-!                 endif
-! End Bigyani's correction
-
-                  if (do_aerocom)then
-                     if ((ic /= INDMS) .and. (ik == k1)) then
-                       concentration(ic)%pArray3D(il,ij,ik) =  &
-     &                   concentration(ic)%pArray3D(il,ij,ik) +  &
-     &                     emiss_dust(il,ij,icx) * tdt/ mass(il,ij,ik)
-                     endif
-                  else
-                     concentration(ic)%pArray3D(il,ij,ik) =  &
-     &                 concentration(ic)%pArray3D(il,ij,ik) +  &
-     &                 emiss_dust(il,ij,icx) * tdt / mass_pbl(il,ij)
-                  end if
-
-                end do
-              end if
-
-!             ------------------------------
-!             Other aerosol (carbon & sslt).
-!             ------------------------------
-
-              if (emiss_aero_opt /= 0) then
-                do icx = 1, naero
-
-                  ic = emiss_map_aero(icx)
-
-                  if ((ic == IBOC) .or. (ic == IBBC)) then
-
-                    concentration(ic)%pArray3D(il,ij,ik) =  &
-     &                concentration(ic)%pArray3D(il,ij,ik) +  &
-     &                emiss_aero(il,ij,icx) * tdt / mass_pbl(il,ij)
-
-                  else if (((ic == INOC)   .or. (ic == IFOC)   .or.  &
-     &                      (ic == IFBC)   .or. (ic == ISSLT1) .or.  &
-     &                      (ic == ISSLT2) .or. (ic == ISSLT3) .or.  &
-     &                      (ic == ISSLT4)) .and.  &
-     &                     (ik == k1)) then
-
-                    concentration(ic)%pArray3D(il,ij,ik) =  &
-     &                concentration(ic)%pArray3D(il,ij,ik) +  &
-     &                emiss_aero(il,ij,icx) * tdt / mass(il,ij,ik)
-
-                  end if
-
-                end do
-              end if
-
-            end do IKLOOP2
-
-          end do
-        end do
-
-!     ======
-      end if
-!     ======
 
 
       return

--- a/GMIchem_GridCompMod.F90
+++ b/GMIchem_GridCompMod.F90
@@ -305,6 +305,11 @@ CONTAINS
       STATUS = 0
 
 
+     CASE("CARMA")
+
+      STATUS = 0
+
+
      CASE("none")
 
       STATUS = 0
@@ -502,7 +507,7 @@ CONTAINS
 
 ! ========================== EXPORT STATE =========================
 
-    IF(TRIM(aeroProviderName) == "GMICHEM") THEN
+    IF(TRIM(aeroProviderName) == "GMICHEM" .or. TRIM(aeroProviderName) == "CARMA") THEN
 
 !   This state is needed by radiation, and contains aerosols and aerosol optics
 !   ---------------------------------------------------------------------------
@@ -1122,10 +1127,10 @@ CONTAINS
    CHARACTER(LEN=ESMF_MAXSTR)      :: providerName
    CHARACTER(LEN=ESMF_MAXSTR), POINTER, DIMENSION(:) :: fieldNames
 
-   INTEGER, PARAMETER :: numAeroes = 13
+   INTEGER, PARAMETER :: numAeroes = 15
    CHARACTER(LEN=ESMF_MAXSTR) :: aeroName(numAeroes) = (/"BCphobic","BCphilic", &
-             "du001   ","du002   ","du003   ","du004   ","OCphobic","OCphilic", &
-             "ss001   ","ss003   ","ss004   ","ss005   ","SO4     "/)
+             "du001   ","du002   ","du003   ","du004   ","du005   ","OCphobic","OCphilic", &
+             "ss001   ","ss002   ","ss003   ","ss004   ","ss005   ","SO4     "/)
 
    rc = 0
 
@@ -1167,7 +1172,7 @@ CONTAINS
    If (ESMF_UtilStringLowerCase(trim(ProviderName)).eq.'none') ProviderName = 'none'
 
    gcGMI%gcPhot%aeroProviderName = TRIM(ProviderName)
-   IF(TRIM(providerName) == "GMICHEM") THEN
+   IF(TRIM(providerName) == "GMICHEM" .or. TRIM(providerName) == "CARMA") THEN
     gcGMI%gcPhot%AM_I_AERO_PROVIDER = .TRUE.
    ELSE
     gcGMI%gcPhot%AM_I_AERO_PROVIDER = .FALSE.
@@ -1479,8 +1484,8 @@ CONTAINS
     CALL MAPL_StateAdd(aero, aeroBundle, __RC__)
 
     DO n = 1,numAeroes
-     CALL MAPL_GetPointer(expChem, PTR3D, "GMICHEM::"//TRIM(aeroName(n)), ALLOC=.TRUE., RC=STATUS)
-     CALL ESMF_StateGet(expChem, "GMICHEM::"//TRIM(aeroName(n)), field, __RC__)
+     CALL MAPL_GetPointer(expChem, PTR3D, TRIM(aeroName(n)), ALLOC=.TRUE., RC=STATUS)
+     CALL ESMF_StateGet(expChem, TRIM(aeroName(n)), field, __RC__)
      renamedField = MAPL_FieldCreate(field, NAME=TRIM(aeroName(n)), __RC__)
      CALL MAPL_FieldBundleAdd(aeroBundle, renamedField, __RC__)
      NULLIFY(PTR3D)
@@ -1505,7 +1510,7 @@ CONTAINS
      END IF
     END DO
 
-    CALL ESMF_MethodAdd(aero, LABEL='aerosol_optics', USERROUTINE=aerosol_optics, __RC__)
+    CALL ESMF_MethodAdd(aero, LABEL='run_aerosol_optics', USERROUTINE=aerosol_optics, __RC__)
 
     IF(MAPL_AM_I_ROOT()) THEN
      PRINT *," "
@@ -1789,7 +1794,7 @@ CONTAINS
 
 ! Replay mode detection
 ! ---------------------
-   CHARACTER(LEN=ESMF_MAXSTR)        :: ReplayMode
+   CHARACTER(LEN=ESMF_MAXSTR)        :: ReplayMode, H2SO4_Source
    TYPE(ESMF_Alarm)                  :: PredictorIsActive
    LOGICAL                           :: doingPredictorNow
 
@@ -2105,21 +2110,23 @@ CONTAINS
 
    END IF Phase99
 
-!.TEMP.. if H2SO4 exists in GMI then ZERO OUT H2SO4 until coupled into GOCART2G
-   SDSTEMP: IF ( phase == 2 .OR. phase == 99 ) THEN
+!... if H2SO4 exists in GMI then ZERO OUT H2SO4 unless coupled into SO4 altering aerosol component
+   H2SO4LOSS: IF ( phase == 2 .OR. phase == 99 ) THEN
      m = 1
      n = ggReg%nq
      iH2SO4 = -1
      DO i = m,n
-       IF(TRIM(ggReg%vname(i)) == "H2SO4") THEN
+       IF (TRIM(ggReg%vname(i)) == "H2SO4") THEN
          iH2SO4 = i
          EXIT
        ENDIF
      ENDDO
+!... 
      IF(iH2SO4 >= 1) THEN
-       bgg%qa(iH2SO4)%data3d(:,:,:) = 1e-30
+       call ESMF_ConfigGetAttribute(CF, H2SO4_Source, LABEL="SULFURIC_ACID_SOURCE:", DEFAULT='tendency', __RC__)
+       if (trim(H2SO4_Source).ne."full_field") bgg%qa(iH2SO4)%data3d(:,:,:) = 1e-30
      ENDIF
-   ENDIF SDSTEMP
+   ENDIF H2SO4LOSS
 
 
 !  Update age-of-air.
@@ -2872,7 +2879,7 @@ subroutine aerosol_optics(state, rc)
   end do
 
   call ESMF_AttributeGet(state, name='mie_table_instance', value=instance, __RC__)
-  call mie_(gocartMieTable(instance, aerosol_names, n_bands, offset, q_4d, rh, ext, ssa, asy, __RC__)
+  call mie_(gocartMieTable(instance), aerosol_names, n_bands, offset, q_4d, rh, ext, ssa, asy, __RC__)
 
   deallocate(dp, f_p, __STAT__)
 #else
@@ -2891,6 +2898,7 @@ subroutine aerosol_optics(state, rc)
   end do
 
   call mie_(gocartMieTable(instance), aerosol_names, n_bands, offset, q_4d, rh, ext, ssa, asy, __RC__)
+
 #endif
   
   call ESMF_AttributeGet(state, name='extinction_in_air_due_to_ambient_aerosol', value=fld_name, __RC__)

--- a/GMIchem_GridCompMod.F90
+++ b/GMIchem_GridCompMod.F90
@@ -299,6 +299,104 @@ CONTAINS
 							RC=STATUS  )
       VERIFY_(STATUS)
 
+     CASE("GOCART2G")
+!   GOCART2G aerosols and dust
+!   --------------------------
+      CALL MAPL_AddImportSpec(GC,                                    &
+            SHORT_NAME  = 'CA.bcphobic',                              &
+            LONG_NAME   = 'CA.bcphobic',                              &
+            UNITS       = 'n/a',                                      &
+            DIMS        = MAPL_DimsHorzVert,                          &
+            VLOCATION   = MAPL_VLocationCenter,        RC=STATUS  )
+      VERIFY_(STATUS)
+   
+      CALL MAPL_AddImportSpec(GC,                                    &
+            SHORT_NAME  = 'CA.bcphilic',                              &
+            LONG_NAME   = 'CA.bcphilic',                              &
+            UNITS       = 'n/a',                                      &
+            DIMS        = MAPL_DimsHorzVert,                          &
+            VLOCATION   = MAPL_VLocationCenter,        RC=STATUS  )
+      VERIFY_(STATUS)
+
+      CALL MAPL_AddImportSpec(GC,                                    &
+            SHORT_NAME  = 'CA.ocphobic',                              &
+            LONG_NAME   = 'CA.ocphobic',                              &
+            UNITS       = 'n/a',                                      &
+            DIMS        = MAPL_DimsHorzVert,                          &
+            VLOCATION   = MAPL_VLocationCenter,        RC=STATUS  )
+      VERIFY_(STATUS)
+
+      CALL MAPL_AddImportSpec(GC,                                    &
+            SHORT_NAME  = 'CA.ocphilic',                              &
+            LONG_NAME   = 'CA.ocphilic',                              &
+            UNITS       = 'n/a',                                      &
+            DIMS        = MAPL_DimsHorzVert,                          &
+            VLOCATION   = MAPL_VLocationCenter,        RC=STATUS  )
+      VERIFY_(STATUS)
+
+      CALL MAPL_AddImportSpec(GC,                                    &
+            SHORT_NAME  = 'CA.brphobic',                              &
+            LONG_NAME   = 'CA.brphobic',                              &
+            UNITS       = 'n/a',                                      &
+            DIMS        = MAPL_DimsHorzVert,                          &
+            VLOCATION   = MAPL_VLocationCenter,        RC=STATUS  )
+      VERIFY_(STATUS)
+
+      CALL MAPL_AddImportSpec(GC,                                    &
+            SHORT_NAME  = 'CA.brphilic',                              &
+            LONG_NAME   = 'CA.brphilic',                              &
+            UNITS       = 'n/a',                                      &
+            DIMS        = MAPL_DimsHorzVert,                          &
+            VLOCATION   = MAPL_VLocationCenter,        RC=STATUS  )
+      VERIFY_(STATUS)
+
+      CALL MAPL_AddImportSpec(GC,                                    &
+            SHORT_NAME  = 'SS',                                       &
+            LONG_NAME   = 'SS',                                       &
+            UNITS       = 'n/a',                                      &
+            DIMS        = MAPL_DimsHorzVert,                          &
+            VLOCATION   = MAPL_VLocationCenter,        RC=STATUS  )
+      VERIFY_(STATUS)
+
+      CALL MAPL_AddImportSpec(GC,                                    &
+            SHORT_NAME  = 'DU',                                       &
+            LONG_NAME   = 'DU',                                       &
+            UNITS       = 'n/a',                                      &
+            DIMS        = MAPL_DimsHorzVert,                          &
+            VLOCATION   = MAPL_VLocationCenter,        RC=STATUS  )
+      VERIFY_(STATUS)
+
+      CALL MAPL_AddImportSpec(GC,                                    &
+            SHORT_NAME  = 'DMS',                                      &
+            LONG_NAME   = 'DMS',                                      &
+            UNITS       = 'n/a',                                      &
+            DIMS        = MAPL_DimsHorzVert,                          &
+            VLOCATION   = MAPL_VLocationCenter,        RC=STATUS  )
+      VERIFY_(STATUS)
+
+      CALL MAPL_AddImportSpec(GC,                                    &
+            SHORT_NAME  = 'SO2',                                      &
+            LONG_NAME   = 'SO2',                                      &
+            UNITS       = 'n/a',                                      &
+            DIMS        = MAPL_DimsHorzVert,                          &
+            VLOCATION   = MAPL_VLocationCenter,        RC=STATUS  )
+      VERIFY_(STATUS)
+
+      CALL MAPL_AddImportSpec(GC,                                    &
+            SHORT_NAME  = 'SO4',                                      &
+            LONG_NAME   = 'SO4',                                      &
+            UNITS       = 'n/a',                                      &
+            DIMS        = MAPL_DimsHorzVert,                          &
+            VLOCATION   = MAPL_VLocationCenter,        RC=STATUS  )
+      VERIFY_(STATUS)
+
+      CALL MAPL_AddImportSpec(GC,                                    &
+            SHORT_NAME  = 'MSA',                                      &
+            LONG_NAME   = 'MSA',                                      &
+            UNITS       = 'n/a',                                      &
+            DIMS        = MAPL_DimsHorzVert,                          &
+            VLOCATION   = MAPL_VLocationCenter,        RC=STATUS  )
+      VERIFY_(STATUS)
 
      CASE("GMICHEM")
 


### PR DESCRIPTION
Enable GOCART2G as aerosol provider. Duplicate how GOCART fields are handled with corresponding GOCART2G fields 
zero diff if aero provider is None.