### PR TITLE
Use solar zenith angle from MAPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Code that might have eventually run GOCART-like aerosols from within the GMI framework (note: doubtful this ever worked and would take significant effort to get working IMHO)
 
+### Changed
+
+- Instead of calling the Gmi routines for SZA (in Chem_Shared), now call a wrapper for the corresponding MAPL routine
 
 ## [1.0.0] - 2023-01-18
 

--- a/GMI_GridComp/GmiChem_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiChem_GridCompClassMod.F90
@@ -672,7 +672,6 @@ CONTAINS
    USE GmiTimeControl_mod,            ONLY : Set_numTimeSteps, Get_numTimeSteps
    USE GmiTimeControl_mod,            ONLY : Set_gmiSeconds, GetSecondsFromJanuary1
    USE GmiSpcConcentrationMethod_mod, ONLY : resetFixedConcentration
-   USE GmiSolar_mod,                  ONLY : CalcCosSolarZenithAngle
    USE GmiChemistryMethod_mod,        ONLY : RunChemistry
 
    IMPLICIT none

--- a/GMI_GridComp/GmiForcingBC_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiForcingBC_GridCompClassMod.F90
@@ -563,7 +563,6 @@ CONTAINS
    USE GmiTimeControl_mod,            ONLY : Set_gmiSeconds, GetSecondsFromJanuary1
    USE GmiTimeControl_mod,            ONLY : Get_gmiSeconds, Get_begGmiDate
    USE GmiSpcConcentrationMethod_mod, ONLY : resetFixedConcentration
-   USE GmiSolar_mod,                  ONLY : CalcCosSolarZenithAngle
    use GmiUpdateForcingBC_mod       , only : updateForcingBC
 
    IMPLICIT none

--- a/GMI_GridComp/GmiPhotolysis_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiPhotolysis_GridCompClassMod.F90
@@ -1148,8 +1148,9 @@ CONTAINS
    USE GmiTimeControl_mod,            ONLY : Set_gmiSeconds, GetSecondsFromJanuary1
    USE GmiTimeControl_mod,            ONLY : GetDaysFromJanuary1, ConvertTimeToSeconds
    USE GmiSpcConcentrationMethod_mod, ONLY : resetFixedConcentration
-   USE GmiSolar_mod,                  ONLY : computeSolarZenithAngle_Photolysis
    USE GmiPhotRateConst_mod,          ONLY : calcPhotolysisRateConstants
+
+   USE SZA_from_MAPL_mod,             ONLY : compute_SZA
 
    IMPLICIT none
 
@@ -1237,8 +1238,6 @@ CONTAINS
    INTEGER, PARAMETER :: ToGMI = 1
    INTEGER, PARAMETER :: FromGMI = -1
 
-   REAL :: pi,degToRad,radToDeg,OneOverDt
-
    REAL, PARAMETER :: mwtAir = 28.9
    REAL, PARAMETER :: rStar = 8.314E+03
    REAL, PARAMETER :: Pa2hPa = 0.01
@@ -1292,23 +1291,9 @@ CONTAINS
    REAL(KIND=DBL), ALLOCATABLE :: ri_(:,:,:)
    REAL(KIND=DBL), ALLOCATABLE :: rl_(:,:,:)
 
-! VV adding Mike's MAPL SZA edits
-   REAL          , ALLOCATABLE ::  ZTH(:,:)
-   REAL          , ALLOCATABLE ::  SLR(:,:)
-   REAL          , ALLOCATABLE :: ZTHP(:,:)
 
    REAL(KIND=DBL), ALLOCATABLE :: solarZenithAngle(:,:)
 
-   TYPE (ESMF_TimeInterval)    ::  GMI_timestep
-   TYPE (ESMF_TimeInterval)    :: MAPL_timestep
-   TYPE (ESMF_Time)            :: CURRENTTIME
-   TYPE (ESMF_Time)            :: SZA_start_time   ! compute average SZA starting at this time
-   TYPE (ESMF_Time)            :: SZA_midpoint
-
-   LOGICAL :: verbose_time   ! To see details on SZA time averaging
-
-   verbose_time = .FALSE.
- 
    loc_proc = -99
 
 !  Grid specs
@@ -1339,11 +1324,7 @@ CONTAINS
 
 !  Some real constants
 !  -------------------
-   pi = 4.00*ATAN(1.00)
-   degToRad = pi/180.00
-   radToDeg = 180.00/pi
    chemDt = tdt
-   OneOverDt = 1.00/tdt
 
    rootProc=.FALSE.
    IF( MAPL_AM_I_ROOT() ) THEN
@@ -1386,17 +1367,7 @@ CONTAINS
    ALLOCATE(               ri_(i1:i2,j1:j2,1:km), __STAT__ )
    ALLOCATE(               rl_(i1:i2,j1:j2,1:km), __STAT__ )
 
-   ALLOCATE(               ZTH(i1:i2,j1:j2), &
-                           SLR(i1:i2,j1:j2), &
-                          ZTHP(i1:i2,j1:j2),     __STAT__ )
-
    
-
-! Geolocation
-! -----------
-!   lonDeg(i1:i2,j1:j2)=self%lonRad(i1:i2,j1:j2)*radToDeg !VV adding Mike's MAPL SZA
-!   latDeg(i1:i2,j1:j2)=self%latRad(i1:i2,j1:j2)*radToDeg
-
 !  Layer mean pressures. NOTE: ple(:,:,0:km)
 !  -----------------------------------------
    DO k=1,km
@@ -1462,85 +1433,10 @@ CONTAINS
 
       IF (self%gotImportRst) THEN
         if (self%phot_opt == 3) then
-! GMI routine, provided SZA > 90
-!         if ((self%phot_opt == 3) then 
 
-!            call GetSecondsFromJanuary1 (nsec_jan1, nymd, nhms)
-
-!            call GetDaysFromJanuary1 (jday, nymd)
-!            time_sec = ConvertTimeToSeconds (nhms)
-
-!            solarZenithAngle(i1:i2,j1:j2) = &
-!                 computeSolarZenithAngle_Photolysis (jday, time_sec, &
-!                          self%fastj_offset_sec, latDeg, lonDeg, i1, i2, j1, j2)
-
-! MEM 6.30.20
-!     Now get the SZA using a MAPL call:
-
-          call ESMF_ClockGet(self%clock, TIMESTEP=MAPL_timestep, currTIME=CURRENTTIME, __RC__ )
-
-          IF( verbose_time .AND. MAPL_AM_I_ROOT() ) THEN
-
-            call ESMF_TimePrint(CURRENTTIME, preString="CURRENTTIME = ", __RC__ )
-
-            print *, "MAPL_timestep = "
-            call ESMF_TimeIntervalPrint(MAPL_timestep, options="string", __RC__ )
-
-          ENDIF
-
-          call ESMF_TimeIntervalSet(GMI_timestep, s=INT(tdt+0.1), __RC__ )
-
-          IF( verbose_time .AND. MAPL_AM_I_ROOT() ) THEN
-
-            print *, "GMI_timestep = "
-            call ESMF_TimeIntervalPrint(GMI_timestep, options="string", __RC__ )
-
-            print *, "computing Photolysis w/ tdt = ", tdt
-
-          ENDIF
-
-          ! We want a starting time = MAPL time + 1/2 MAPL timestep - 1/2 GMI timestep
-          ! We want a time interval == GMI timestep
-
-          ! Position SZA_midpoint to be midpoint of MAPL_timestep
-          SZA_midpoint = CURRENTTIME + (MAPL_timestep/2)
-
-          ! Position SZA_start_time to be half of a GMI timestep earlier
-          SZA_start_time = SZA_midpoint - (GMI_timestep/2)
-
-          IF( verbose_time .AND. MAPL_AM_I_ROOT() ) THEN
-            call ESMF_TimePrint(SZA_start_time,              preString="SZA averaging start_time = ", __RC__ )
-            call ESMF_TimePrint(SZA_start_time+GMI_timestep, preString="SZA averaging   end_time = ", __RC__ )
-          ENDIF
-
-! Calling sequence from SOLAR GridComp:
-!     call MAPL_SunGetInsolation(   &
-!             self%lonRad,          &    !  from the MAPL_Get  REAL, pointer, (IM,JM)
-!             self%latRad,          &    !  from the MAPL_Get  REAL, pointer, (IM,JM)
-!             self%orbit,           &    !  from MAPL_Get      type (MAPL_SunOrbit)
-!             ZTH,                  &    !  OUT                REAL,          (IM,JM)
-!             SLR,                  &    !  OUT                REAL,          (IM,JM)
-!             INTV = MAPL_timestep, &    !  INOUT              type (ESMF_TimeInterval)
-!                                   &    !   the CLOCK timestep    [optional]   Why INOUT?
-!             CLOCK = self%clock,   &    !  IN   [optional]    type(ESMF_Clock)
-!         !   TIME = SUNFLAG,       &    !  IN   [optional]    INTEGER
-!         !   ZTHN = ZTHN,          &    !  OUT  [optional]    REAL,          (IM,JM )
-!             ZTHP = ZTHP,          &    !  OUT  [optional]    REAL,          (IM,JM)
-!             RC=STATUS )
-!     VERIFY_(STATUS)
-
-          call MAPL_SunGetInsolation(        &
-                  self%lonRad,               &
-                  self%latRad,               &
-                  self%orbit,                &
-                  ZTH,                       &
-                  SLR,                       &
-                  CURRTIME = SZA_start_time, &
-                  INTV     = GMI_timestep,   &
-                  ZTHP     = ZTHP,           &
-                  __RC__ )
-
-          solarZenithAngle(i1:i2,j1:j2) = ACOS( ZTHP ) * radToDeg
+          call compute_SZA ( LONS=self%lonRad, LATS=self%latRad, ORBIT=self%orbit, &
+                             CLOCK=self%clock, tdt=tdt, label='GMI-PHOT', &
+                             SZA=solarZenithAngle, __RC__ )
 
           call calcPhotolysisRateConstants (self%JXbundle,                     &
                      tropopausePress,                         &
@@ -1596,7 +1492,7 @@ CONTAINS
               moistq, STAT=STATUS)
    VERIFY_(STATUS)
 
-   DEALLOCATE(tau_clw, tau_cli, qi_, ql_, ri_, rl_, ZTH, SLR, ZTHP, STAT=STATUS)
+   DEALLOCATE(tau_clw, tau_cli, qi_, ql_, ri_, rl_, STAT=STATUS)
    VERIFY_(STATUS)
 
 ! IMPORTANT: Reset this switch to .TRUE. after first pass.

--- a/GMI_GridComp/GmiSAD_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiSAD_GridCompClassMod.F90
@@ -643,7 +643,6 @@ CONTAINS
    USE GmiTimeControl_mod,            ONLY : Set_curGmiDate, Set_curGmiTime
    USE GmiTimeControl_mod,            ONLY : Set_numTimeSteps, Get_numTimeSteps
    USE GmiTimeControl_mod,            ONLY : Set_gmiSeconds, GetSecondsFromJanuary1
-   USE GmiSolar_mod,                  ONLY : CalcCosSolarZenithAngle
    USE GmiSpcConcentrationMethod_mod, ONLY : resetFixedConcentration
    USE GmiUpdateSAD_mod,              ONLY : updateSurfaceAreaDensities
 

--- a/GMI_GridComp/GmiThermalRC_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiThermalRC_GridCompClassMod.F90
@@ -509,7 +509,6 @@ CONTAINS
    USE GmiTimeControl_mod,            ONLY : Set_numTimeSteps, Get_numTimeSteps
    USE GmiTimeControl_mod,            ONLY : Set_gmiSeconds, GetSecondsFromJanuary1
    USE GmiSpcConcentrationMethod_mod, ONLY : resetFixedConcentration
-   USE GmiSolar_mod,                  ONLY : CalcCosSolarZenithAngle
    use GmiThermalRateConstants_mod  , only : calcThermalRateConstants
 
    IMPLICIT none

--- a/GMIchem_GridCompMod.F90
+++ b/GMIchem_GridCompMod.F90
@@ -1358,6 +1358,8 @@ CONTAINS
    gcGMI%gcDepos%j2 = j2
    gcGMI%gcDepos%jm = jm
    gcGMI%gcDepos%km = km
+   gcGMI%gcDepos%orbit = ORBIT
+   gcGMI%gcDepos%clock = CLOCK
    
    gcGMI%gcEmiss%i1 = i1
    gcGMI%gcEmiss%i2 = i2
@@ -1383,7 +1385,7 @@ CONTAINS
    gcGMI%gcPhot%j2 = j2
    gcGMI%gcPhot%jm = jm
    gcGMI%gcPhot%km = km
-   gcGMI%gcPhot%orbit = ORBIT ! VV adding Mike's SZA edits
+   gcGMI%gcPhot%orbit = ORBIT
    gcGMI%gcPhot%clock = CLOCK
    
    gcGMI%gcSAD%i1 = i1


### PR DESCRIPTION
GMI photolysis switched to using MAPL SZA months ago, but GMI deposition and emissions have been using the old gmi-solar implementation; GMI now calls a new wrapper (for getting SZA from MAPL) from all 3 points in the code. It is slightly non-zero-diff for all GMI simulations.

This PR goes together with changes in the Chemistry and TR repo's.
https://github.com/GEOS-ESM/GEOSchem_GridComp/pull/255
https://github.com/GEOS-ESM/TR/pull/1