### PR TITLE
AERO_PROVIDER can now be GOCART2G, GMICHEM;  get SZA from MAPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,25 +18,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 
-## [as of 24Mar2023]
+## [1.1.0] - 2023-04-24
 
 ### Added
 
+- Capability for AERO_PROVIDER=GOCART2G
 - Capability for AERO_PROVIDER=GMICHEM
 - Capability for AERO_PROVIDER=CARMA (uses GMICHEM right now)
-- Connectivity from GOCART2G to GMI chem
 
 ### Changed
 
+- Instead of calling the GMI routines for SZA (in Chem_Shared), now call a wrapper for the corresponding MAPL routine
 - Changed default aerosdust filename (for case AERO_PROVIDER=GMICHEM)
 
 ### Removed
 
 - Code that might have eventually run GOCART-like aerosols from within the GMI framework (note: doubtful this ever worked and would take significant effort to get working IMHO)
-
-### Changed
-
-- Instead of calling the Gmi routines for SZA (in Chem_Shared), now call a wrapper for the corresponding MAPL routine
 
 ## [1.0.0] - 2023-01-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+
+### Added
+
+- Capability for AERO_PROVIDER=GMICHEM
+- Capability for AERO_PROVIDER=CARMA (uses GMICHEM right now)
+
+### Removed
+
+- Code that might have eventually run GOCART-like aerosols from within the GMI framework (note: doubtful this ever worked and would take significant effort to get working IMHO)
+
+
 ## [1.0.0] - 2023-01-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Code that might have eventually run GOCART-like aerosols from within the GMI framework (note: doubtful this ever worked and would take significant effort to get working IMHO)
 
+### Changed
+
+- Instead of calling the Gmi routines for SZA (in Chem_Shared), now call a wrapper for the corresponding MAPL routine
 
 ## [1.0.0] - 2023-01-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Capability for AERO_PROVIDER=GMICHEM
 - Capability for AERO_PROVIDER=CARMA (uses GMICHEM right now)
+- Connectivity from GOCART2G to GMI chem
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 
+## [as of 24Mar2023]
+
 ### Added
 
 - Capability for AERO_PROVIDER=GMICHEM
 - Capability for AERO_PROVIDER=CARMA (uses GMICHEM right now)
+
+### Changed
+
+- Changed default aerosdust filename (for case AERO_PROVIDER=GMICHEM)
 
 ### Removed
 

--- a/GMI_GridComp/GMI_ExtData.rc
+++ b/GMI_GridComp/GMI_ExtData.rc
@@ -79,23 +79,22 @@ MEGAN_LAI_009      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_009	 ExtData/g5
 MEGAN_LAI_010      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_010	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
 MEGAN_LAI_011      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_011	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
 MEGAN_LAI_012      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_012	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-BC1                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  BC1		 /dev/null
-BC2                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  BC2		 /dev/null
-OC1                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  OC1		 /dev/null
-OC2                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  OC2		 /dev/null
-SS1                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SS1		 /dev/null
-SS2                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SS2		 /dev/null
-SS3                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SS3		 /dev/null
-SS4                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SS4		 /dev/null
-SO4                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SO4		 /dev/null
-SO4v                'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SO4v		 /dev/null
-MDUST1              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST1		 /dev/null
-MDUST2              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST2		 /dev/null
-MDUST3              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST3		 /dev/null
-MDUST4              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST4		 /dev/null
-MDUST5              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST5		 /dev/null
-MDUST6              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST6		 /dev/null
-MDUST7              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST7		 /dev/null
+BCphobic           'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  BCPHOBIC          /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+BCphilic           'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  BCPHILIC          /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+OCphobic           'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  OCPHOBIC          /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+OCphilic           'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  OCPHILIC          /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+ss001              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS001             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+ss002              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS002             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+ss003              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS003             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+ss004              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS004             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+ss005              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS005             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+SO4                'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SO4               /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+SO4v               'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SO4v              /dev/null
+du001              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU001             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+du002              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU002             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+du003              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU003             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+du004              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU004             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+du005              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU005             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
 # -----------|--------------|-----|---|----------------------|--------|-------|-----------------|----------------------   
 %%
 

--- a/GMI_GridComp/GMI_ExtData.rc
+++ b/GMI_GridComp/GMI_ExtData.rc
@@ -79,22 +79,22 @@ MEGAN_LAI_009      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_009	 ExtData/g5
 MEGAN_LAI_010      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_010	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
 MEGAN_LAI_011      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_011	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
 MEGAN_LAI_012      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_012	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-BCphobic           'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  BCPHOBIC          /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
-BCphilic           'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  BCPHILIC          /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
-OCphobic           'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  OCPHOBIC          /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
-OCphilic           'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  OCPHILIC          /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
-ss001              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS001             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
-ss002              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS002             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
-ss003              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS003             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
-ss004              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS004             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
-ss005              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS005             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
-SO4                'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SO4               /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+BCphobic           'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  BCPHOBIC          ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4
+BCphilic           'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  BCPHILIC          ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4
+OCphobic           'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  OCPHOBIC          ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4
+OCphilic           'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  OCPHILIC          ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4
+ss001              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS001             ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4
+ss002              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS002             ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4
+ss003              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS003             ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4
+ss004              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS004             ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4
+ss005              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SS005             ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4
+SO4                'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SO4               ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4
 SO4v               'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  SO4v              /dev/null
-du001              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU001             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
-du002              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU002             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
-du003              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU003             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
-du004              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU004             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
-du005              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU005             /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+du001              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU001             ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4
+du002              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU002             ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4
+du003              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU003             ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4
+du004              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU004             ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4
+du005              'kg m-3'     Y   Y   %y4-%m2-%d2T12:00:00     none    none  DU005             ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4
 # -----------|--------------|-----|---|----------------------|--------|-------|-----------------|----------------------   
 %%
 

--- a/GMI_GridComp/GMI_ExtData.yaml
+++ b/GMI_GridComp/GMI_ExtData.yaml
@@ -35,6 +35,8 @@ Collections:
     template: ExtData/CMIP6/L72/SAD/sad_wt_CMIP6_288x181x72_%y4.nc
   GMI_veg_fraction_x720_y360_t12_2008.nc:
     template: ExtData/g5chem/sfc/LAI/veg_fraction_x720_y360_t12_2008.nc
+  GMI_aerodust_file:
+    template: /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
 
 Samplings:
   GMI_sample_0:
@@ -54,6 +56,68 @@ Samplings:
     extrapolation: clim
 
 Exports:
+  BCphobic:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: BCPHOBIC
+  BCphilic:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: BCPHILIC
+  OCphobic:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: OCPHOBIC
+  OCphilic:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: OCPHILIC
+  SO4:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: SO4
+  SO4v:
+    collection: /dev/null
+  ss001:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: SS001
+  ss002:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: SS002
+  ss003:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: SS003
+  ss004:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: SS004
+  ss005:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: SS005
+  du001:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: DU001
+  du002:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: DU002
+  du003:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: DU003
+  du004:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: DU004
+  du005:
+    collection: GMI_aerodust_file
+    sample: GMI_sample_2
+    variable: DU005
   ACET_FIXED:
     collection: GMI_acetone_fixed_GMI.x288_y181_z72_t12.2001.nc
     sample: GMI_sample_0
@@ -77,10 +141,6 @@ Exports:
     regrid: CONSERVE
     sample: GMI_sample_1
     variable: ALK4_ff
-  BC1:
-    collection: /dev/null
-  BC2:
-    collection: /dev/null
   C2H6_biof:
     collection: /dev/null
   C2H6_biom:
@@ -177,20 +237,6 @@ Exports:
     collection: GMI_lai_x720_y360_v72_t12_2008.nc
     sample: GMI_sample_0
     variable: LAI_FRAC
-  MDUST1:
-    collection: /dev/null
-  MDUST2:
-    collection: /dev/null
-  MDUST3:
-    collection: /dev/null
-  MDUST4:
-    collection: /dev/null
-  MDUST5:
-    collection: /dev/null
-  MDUST6:
-    collection: /dev/null
-  MDUST7:
-    collection: /dev/null
   MEGAN_ISOP:
     collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
     regrid: CONSERVE
@@ -309,10 +355,6 @@ Exports:
     collection: /dev/null
   NO_ship:
     collection: /dev/null
-  OC1:
-    collection: /dev/null
-  OC2:
-    collection: /dev/null
   OCS_CLIMO:
     collection: GMI_OCS_vmr.x360_y181_z72.t12.2016.nc4
     sample: GMI_sample_0
@@ -363,10 +405,6 @@ Exports:
     regrid: CONSERVE
     sample: GMI_sample_1
     variable: SO2_shipping
-  SO4:
-    collection: /dev/null
-  SO4v:
-    collection: /dev/null
   SOILFERT:
     collection: GMI_fertilizer_GMI.x288_y181_t12.2006.nc
     regrid: CONSERVE
@@ -376,17 +414,7 @@ Exports:
     collection: GMI_precipitation_GMI.x288_y181_t12.2006.nc
     sample: GMI_sample_0
     variable: soilPrecip
-  SS1:
-    collection: /dev/null
-  SS2:
-    collection: /dev/null
-  SS3:
-    collection: /dev/null
-  SS4:
-    collection: /dev/null
   VEG_FRAC:
     collection: GMI_veg_fraction_x720_y360_t12_2008.nc
     sample: GMI_sample_0
     variable: VEG_FRAC
-
-

--- a/GMI_GridComp/GMI_ExtData.yaml
+++ b/GMI_GridComp/GMI_ExtData.yaml
@@ -36,7 +36,7 @@ Collections:
   GMI_veg_fraction_x720_y360_t12_2008.nc:
     template: ExtData/g5chem/sfc/LAI/veg_fraction_x720_y360_t12_2008.nc
   GMI_aerodust_file:
-    template: /discover/nobackup/ssteenro/GEOS/GEOSCCM_aerodust_MERRA2_tavg3D_2012.nc
+    template: ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4
 
 Samplings:
   GMI_sample_0:

--- a/GMI_GridComp/GmiChem_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiChem_GridCompClassMod.F90
@@ -672,7 +672,6 @@ CONTAINS
    USE GmiTimeControl_mod,            ONLY : Set_numTimeSteps, Get_numTimeSteps
    USE GmiTimeControl_mod,            ONLY : Set_gmiSeconds, GetSecondsFromJanuary1
    USE GmiSpcConcentrationMethod_mod, ONLY : resetFixedConcentration
-   USE GmiSolar_mod,                  ONLY : CalcCosSolarZenithAngle
    USE GmiChemistryMethod_mod,        ONLY : RunChemistry
 
    IMPLICIT none

--- a/GMI_GridComp/GmiChemistry/AerosolDust/GmiAerDustODSA_mod.F90
+++ b/GMI_GridComp/GmiChemistry/AerosolDust/GmiAerDustODSA_mod.F90
@@ -561,7 +561,7 @@
 ! !LOCAL VARIABLES:
       REAL*8       :: MSDENS(NSADdust)
 
-      integer      :: i, j , k, l, n, r
+      integer      :: i, j, k, l, n, r
 !
 ! !REVISION HISTORY:
 !   February2005, Jules Kouatchou (Jules.Kouatchou.1@gsfc.nasa.gov)

--- a/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_Registry.rc
+++ b/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_Registry.rc
@@ -142,23 +142,22 @@
   MEGAN_LAI_010      |  cm cm-2        | xy  |   |    |   |   |     |	   |  x | AVHRR_leaf_area_index_oct_2000
   MEGAN_LAI_011      |  cm cm-2        | xy  |   |    |   |   |     |	   |  x | AVHRR_leaf_area_index_nov_2000
   MEGAN_LAI_012      |  cm cm-2        | xy  |   |    |   |   |     |	   |  x | AVHRR_leaf_area_index_dec_2000
-  BC1                |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophobic_black_carbon
-  BC2                |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophilic_black_carbon
-  OC1                |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophobic_organic_carbon
-  OC2                |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophilic_organic_carbon
-  SS1                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
-  SS2                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
-  SS3                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
-  SS4                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  BCphobic           |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophobic_black_carbon
+  BCphilic           |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophilic_black_carbon
+  OCphobic           |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophobic_organic_carbon
+  OCphilic           |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophilic_organic_carbon
+  ss001              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  ss002              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  ss003              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  ss004              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  ss005              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
   SO4                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sulfate
   SO4v               |  kg m-3         | xyz | C |    |   |   |     |      |  x | sulfate_from_volcanos
-  MDUST1             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST2             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST3             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST4             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST5             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST6             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST7             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du001              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du002              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du003              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du004              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du005              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
 # -------------------|-----------------|-----|---|----|---|---|-----|------|--------------------------
 </ImportSpec>
 
@@ -171,19 +170,21 @@
 #  Short	    |		     |     | V |Item|Intervl| Sub |	     Long
 #  Name 	    |   Units	     | Dim |Loc|Type| R | A |Tiles|	     Name
 # ------------------|----------------|-----|---|----|---|---|-----|---------------------------------
-  GMICHEM::BCphobic | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_hydrophobic_black_carbon_from_GMICHEM
-  GMICHEM::BCphilic | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_hydrophylic_black_carbon_from_GMICHEM
-  GMICHEM::du001    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_dust_bin_1_from_GMICHEM
-  GMICHEM::du002    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_dust_bin_2_from_GMICHEM
-  GMICHEM::du003    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_dust_bin_3_from_GMICHEM
-  GMICHEM::du004    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_dust_bin_4_from_GMICHEM
-  GMICHEM::OCphobic | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_hydrophobic_organic_carbon_from_GMICHEM
-  GMICHEM::OCphilic | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_hydrophylic_organic_carbon_from_GMICHEM
-  GMICHEM::ss001    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sea_salt_bin_1_from_GMICHEM
-  GMICHEM::ss003    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sea_salt_bin_3_from_GMICHEM
-  GMICHEM::ss004    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sea_salt_bin_4_from_GMICHEM
-  GMICHEM::ss005    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sea_salt_bin_5_from_GMICHEM
-  GMICHEM::SO4      | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sulfate_from_GMICHEM
+  BCphobic | kg kg-1        | xyz | C |    |   |   |     | prescribed_hydrophobic_black_carbon_from_GMICHEM
+  BCphilic | kg kg-1        | xyz | C |    |   |   |     | prescribed_hydrophylic_black_carbon_from_GMICHEM
+  du001    | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_1_from_GMICHEM
+  du002    | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_2_from_GMICHEM
+  du003    | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_3_from_GMICHEM
+  du004    | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_4_from_GMICHEM
+  du005    | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_4_from_GMICHEM
+  OCphobic | kg kg-1        | xyz | C |    |   |   |     | prescribed_hydrophobic_organic_carbon_from_GMICHEM
+  OCphilic | kg kg-1        | xyz | C |    |   |   |     | prescribed_hydrophylic_organic_carbon_from_GMICHEM
+  ss001    | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_1_from_GMICHEM
+  ss002    | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_1_from_GMICHEM
+  ss003    | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_3_from_GMICHEM
+  ss004    | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_4_from_GMICHEM
+  ss005    | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_5_from_GMICHEM
+  SO4      | kg kg-1        | xyz | C |    |   |   |     | prescribed_sulfate_from_GMICHEM
   REFFICE  	    | cm  	     | xyz | C |    |	|   |	  | ice_aerosol_effective_radius
   REFFSTS 	    | cm  	     | xyz | C |    |	|   |	  | STS_aerosol_effective_radius
   VFALL   	    | cm s-1	     | xyz | C |    |	|   |	  | effective_aerosol_fall_velocity

--- a/GMI_GridComp/GmiChemistry/StratTrop_Orig/GMI_Registry.rc
+++ b/GMI_GridComp/GmiChemistry/StratTrop_Orig/GMI_Registry.rc
@@ -132,23 +132,22 @@
   MEGAN_LAI_010      |  cm cm-2        | xy  |   |    |   |   |     |	   |  x | AVHRR_leaf_area_index_oct_2000
   MEGAN_LAI_011      |  cm cm-2        | xy  |   |    |   |   |     |	   |  x | AVHRR_leaf_area_index_nov_2000
   MEGAN_LAI_012      |  cm cm-2        | xy  |   |    |   |   |     |	   |  x | AVHRR_leaf_area_index_dec_2000
-  BC1                |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophobic_black_carbon
-  BC2                |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophilic_black_carbon
-  OC1                |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophobic_organic_carbon
-  OC2                |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophilic_organic_carbon
-  SS1                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
-  SS2                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
-  SS3                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
-  SS4                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  BCphobic           |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophobic_black_carbon
+  BCphilic           |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophilic_black_carbon
+  OCphobic           |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophobic_organic_carbon
+  OCphilic           |  kg m-3         | xyz | C |    |   |   |     |      |  x | hydrophilic_organic_carbon
+  ss001              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  ss002              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  ss003              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  ss004              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
+  ss005              |  kg m-3         | xyz | C |    |   |   |     |      |  x | sea_salt
   SO4                |  kg m-3         | xyz | C |    |   |   |     |      |  x | sulfate
   SO4v               |  kg m-3         | xyz | C |    |   |   |     |      |  x | sulfate_from_volcanos
-  MDUST1             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST2             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST3             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST4             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST5             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST6             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
-  MDUST7             |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du001              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du002              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du003              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du004              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
+  du005              |  kg m-3         | xyz | C |    |   |   |     |      |  x | dust
 # -------------------|-----------------|-----|---|----|---|---|-----|------|--------------------------
 </ImportSpec>
 
@@ -161,19 +160,21 @@
 #  Short	    |		     |     | V |Item|Intervl| Sub |	     Long
 #  Name 	    |   Units	     | Dim |Loc|Type| R | A |Tiles|	     Name
 # ------------------|----------------|-----|---|----|---|---|-----|---------------------------------
-  GMICHEM::BCphobic | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_hydrophobic_black_carbon_from_GMICHEM
-  GMICHEM::BCphilic | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_hydrophylic_black_carbon_from_GMICHEM
-  GMICHEM::du001    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_dust_bin_1_from_GMICHEM
-  GMICHEM::du002    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_dust_bin_2_from_GMICHEM
-  GMICHEM::du003    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_dust_bin_3_from_GMICHEM
-  GMICHEM::du004    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_dust_bin_4_from_GMICHEM
-  GMICHEM::OCphobic | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_hydrophobic_organic_carbon_from_GMICHEM
-  GMICHEM::OCphilic | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_hydrophylic_organic_carbon_from_GMICHEM
-  GMICHEM::ss001    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sea_salt_bin_1_from_GMICHEM
-  GMICHEM::ss003    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sea_salt_bin_3_from_GMICHEM
-  GMICHEM::ss004    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sea_salt_bin_4_from_GMICHEM
-  GMICHEM::ss005    | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sea_salt_bin_5_from_GMICHEM
-  GMICHEM::SO4      | kg kg-1  	     | xyz | C |    |	|   |     | prescribed_sulfate_from_GMICHEM
+  BCphobic          | kg kg-1        | xyz | C |    |   |   |     | prescribed_hydrophobic_black_carbon_from_GMICHEM
+  BCphilic          | kg kg-1        | xyz | C |    |   |   |     | prescribed_hydrophylic_black_carbon_from_GMICHEM
+  du001             | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_1_from_GMICHEM
+  du002             | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_2_from_GMICHEM
+  du003             | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_3_from_GMICHEM
+  du004             | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_4_from_GMICHEM
+  du005             | kg kg-1        | xyz | C |    |   |   |     | prescribed_dust_bin_4_from_GMICHEM
+  OCphobic          | kg kg-1        | xyz | C |    |   |   |     | prescribed_hydrophobic_organic_carbon_from_GMICHEM
+  OCphilic          | kg kg-1        | xyz | C |    |   |   |     | prescribed_hydrophylic_organic_carbon_from_GMICHEM
+  ss001             | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_1_from_GMICHEM
+  ss002             | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_1_from_GMICHEM
+  ss003             | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_3_from_GMICHEM
+  ss004             | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_4_from_GMICHEM
+  ss005             | kg kg-1        | xyz | C |    |   |   |     | prescribed_sea_salt_bin_5_from_GMICHEM
+  SO4               | kg kg-1        | xyz | C |    |   |   |     | prescribed_sulfate_from_GMICHEM
   REFFICE  	    | cm  	     | xyz | C |    |	|   |	  | ice_aerosol_effective_radius
   REFFSTS 	    | cm  	     | xyz | C |    |	|   |	  | STS_aerosol_effective_radius
   VFALL   	    | cm s-1	     | xyz | C |    |	|   |	  | effective_aerosol_fall_velocity

--- a/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
@@ -137,8 +137,7 @@
      LOGICAL :: pr_diag
      LOGICAL :: do_drydep
      LOGICAL :: do_wetdep
-     LOGICAL :: do_emission             
-     LOGICAL :: do_aerocom             
+     LOGICAL :: do_emission            
      LOGICAL :: pr_const
      LOGICAL :: do_synoz
      LOGICAL :: do_gcr
@@ -399,10 +398,6 @@
 
     call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_const, &
               label="pr_const:", default=.false., rc=STATUS )
-    VERIFY_(STATUS)
-
-    call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_aerocom, &
-              label="do_aerocom:", default=.false., rc=STATUS )
     VERIFY_(STATUS)
 
     call ESMF_ConfigGetAttribute(gmiConfigFile, self%metdata_name_org, &
@@ -815,7 +810,7 @@
    INTEGER,                 INTENT(IN)    :: nymd, nhms  ! time
    REAL,                    INTENT(IN)    :: tdt         ! chemical timestep (secs)
    LOGICAL,                 INTENT(IN)    :: mixPBL      ! whether to explicitly distribute
-                                                         ! aerosol emissions within the PBL
+                                                         ! emissions within the PBL
 ! !OUTPUT PARAMETERS:
 
    INTEGER,                 INTENT(OUT)   :: rc          ! Error return code:
@@ -1184,7 +1179,7 @@
                      ISSLT3, ISSLT4, IFSO2, INSO2, INDMS, IAN, IMGAS, INO,     &
                      IC5H8, INO, ICO, IC3H6, IHNO3, IO3, NSP, diffusePAR,      &
                      directPAR, T_15_AVG, self%met_opt, self%chem_opt,         &
-                     self%trans_opt, self%do_aerocom, self%do_drydep,          &
+                     self%trans_opt, self%do_drydep,          &
                      self%pr_diag, self%pr_const, self%pr_surf_emiss,          &
                      self%pr_emiss_3d, self%metdata_name_org,                  &
                      self%metdata_name_model, tdt, mixPBL, light_NO_prod)

--- a/GMI_GridComp/GmiEmission/llnl/emiss_llnl.F90
+++ b/GMI_GridComp/GmiEmission/llnl/emiss_llnl.F90
@@ -13,13 +13,6 @@
 !   Add_Emiss_Llnl
 !
 ! HISTORY
-!   - December 8, 2005 * Bigyani Das
-!     Changes are made for the aerocom run which are controlled by 2 parameters
-!     do_aerocom and do_dust_emiss to add dust and sea salt emissions in 
-!     the model's  1st level. Originally sea salt emissions 
-!     were added in the emission fields with carbon emission, 
-!     now it is added with dust (dust and sea salt emissions are now 
-!     in the same files, before sea salt emissions were with carbon).
 !=============================================================================
 
 
@@ -49,26 +42,20 @@
 !   const          : species concentration, known at zone centers
 !                    (mixing ratio)
 !   emiss          : array of emissions (kg/s)
-!   emiss_dust     : tbd
-!   emiss_aero     :
 !   pbl            :
 !-----------------------------------------------------------------------------
 
       subroutine Add_Emiss_Llnl  &
-     &  (do_aerocom, pr_surf_emiss, pr_emiss_3d, mcor, surf_emiss_out, emiss_3d_out,  &
-     &   mass, concentration, emissionArray, emiss_dust, emiss_aero_t, emiss_aero, pbl, &
+     &  (pr_surf_emiss, pr_emiss_3d, mcor, surf_emiss_out, emiss_3d_out,  &
+     &   mass, concentration, emissionArray, pbl, &
      &   gridBoxHeight, IBOC, IBBC, INOC, IFOC, IFBC, ISSLT1, ISSLT2, ISSLT3, ISSLT4, &
-     &   IFSO2, INSO2, INDMS, pr_diag, loc_proc, chem_opt, trans_opt, emiss_aero_opt, &
-     &   emiss_dust_opt, do_semiss_inchem, emiss_map, emiss_map_dust, emiss_map_aero, &
-     &   emissionSpeciesLayers, ndust, naero, nymd, mw, tdt, emiss_timpyr, num_emiss, &
+     &   IFSO2, INSO2, INDMS, pr_diag, loc_proc, chem_opt, trans_opt, &
+     &   do_semiss_inchem, emiss_map, &
+     &   emissionSpeciesLayers, nymd, mw, tdt, emiss_timpyr, num_emiss, &
      &   i1, i2, ju1, j2, k1, k2, ilo, ihi, julo, jhi, num_species, mixPBL)
 
       use GmiArrayBundlePointer_mod, only : t_GmiArrayBundle
       use GmiTimeControl_mod  , only : GmiSplitDateTime
-      use GmiSeaSaltMethod_mod, only : SourceSeaSalt
-      use GmiSeaSaltMethod_mod, only : srcEmissSeaSalt
-      use GmiDustMethod_mod   , only : SourceDust
-      use GmiDustMethod_mod   , only : srcEmissDust
 
       implicit none
 
@@ -85,30 +72,25 @@
       integer, intent(in   ) :: loc_proc
       integer, intent(in   ) :: i1, i2, ju1, j2, k1, k2, ilo, ihi, julo, jhi
       integer, intent(in   ) :: num_species, emiss_timpyr, num_emiss
-      integer, intent(in   ) :: ndust, naero, nymd
+      integer, intent(in   ) :: nymd
       real*8 , intent(in   ) :: mw(num_species)
       real*8 , intent(in   ) :: tdt
-      integer, intent(in   ) :: chem_opt, trans_opt, emiss_aero_opt, emiss_dust_opt
-      integer, intent(in   ) :: emiss_map(num_species), emiss_map_dust(num_species)
-      integer, intent(in   ) :: emiss_map_aero(num_species)
+      integer, intent(in   ) :: chem_opt, trans_opt
+      integer, intent(in   ) :: emiss_map(num_species)
       logical, intent(in   ) :: do_semiss_inchem
-      logical, intent(in   ) :: do_aerocom
       logical, intent(in   ) :: pr_surf_emiss, pr_emiss_3d
       real*8 , intent(in   ) :: mcor (i1:i2, ju1:j2)
       real*8 , intent(inout) :: surf_emiss_out(i1:i2, ju1:j2, num_species)
       real*8 , intent(inout) :: emiss_3d_out(i1:i2, ju1:j2, k1:k2, num_species)
       real*8 , intent(in   ) :: mass (i1:i2, ju1:j2, k1:k2)
 !      real*8 , intent(in   ) :: emiss(i1:i2, ju1:j2, k1:k2, num_emiss)
-      real*8 , intent(inout) :: emiss_dust(i1:i2, ju1:j2, ndust)
-      real*8 , intent(in   ) :: emiss_aero_t(i1:i2, ju1:j2, naero, emiss_timpyr)
-      real*8 , intent(out  ) :: emiss_aero(i1:i2, ju1:j2, naero)
       real*8 , intent(in   ) :: pbl (i1:i2, ju1:j2)
       real*8 , intent(in   ) :: gridBoxHeight(i1:i2, ju1:j2, k1:k2)
       type (t_GmiArrayBundle), intent(inout) :: concentration(num_species)
       type (t_GmiArrayBundle), intent(inout) :: emissionArray(num_emiss  )
       integer, intent(in   ) :: emissionSpeciesLayers(num_species)
       logical, intent(in   ) :: mixPBL    ! whether to explicitly distribute
-                                          ! aerosol emissions within the PBL
+                                          ! emissions within the PBL
 
 !     ----------------------
 !     Variable declarations.
@@ -298,7 +280,6 @@
 
           END IF
 
-
 !                                ============
           if (inum == num_emiss) exit SPCLOOP
 !                                ============
@@ -308,130 +289,6 @@
 !     ==============
       end do SPCLOOP
 !     ==============
-
-!     ----------------------
-!     GMI or GOCART aerosols
-!     ----------------------
-
-      if (emiss_timpyr == MONTHS_PER_YEAR) then
-        call GmiSplitDateTime  (nymd, idumyear, month, idumday)
-        it = month
-      else
-        it = 1
-      end if
-
-      if (emiss_aero_opt == 1) then                        ! GMI    aerosol emissions
-         emiss_aero(i1:i2,ju1:j2,1:naero) = emiss_aero_t(i1:i2,ju1:j2,1:naero,it)
-      elseif (emiss_aero_opt == 2) then                    ! GOCART aerosol emissions
-         emiss_aero(i1:i2,ju1:j2,1:5)     = emiss_aero_t(i1:i2,ju1:j2,1:5,it)
-      end if
-
-!     =====================================================
-      if ((emiss_aero_opt /= 0) .or. (emiss_dust_opt /= 0)) then
-!     =====================================================
-
-
-!       -------------------------------------------------------------------
-!       Add dust emission and other aerosols to some lowest vertical levels
-!       (emitted uniformly below the PBL).
-!       -------------------------------------------------------------------
-
-!       ----------------------------------------------------------------
-!       Add dust and aerosol emissions (kg/s) to concentrations; unit of
-!       aerosol and dust concentrations is kg/(kg air).
-!       ----------------------------------------------------------------
-
-!!!!! GOCART Source for dust
-        if (emiss_dust_opt == 2) then
-           call SourceDust (mcor, tdt, nymd, i1, i2, ju1, j2, k1, k2)
-           emiss_dust(i1:i2,ju1:j2,1:ndust) = srcEmissDust(i1:i2,ju1:j2,1:ndust)
-        end if
-!!!!! GOCART Source for sea salt
-        if (emiss_aero_opt == 2) then
-           call SourceSeaSalt (mcor, tdt, nymd, i1, i2, ju1, j2, k1, k2)
-           emiss_aero(i1:i2,ju1:j2,6:naero) = srcEmissSeaSalt(i1:i2,ju1:j2,1:4)
-        end if
-!!!!!
-
-        do ij = ju1, j2
-          do il = i1, i2
-
-            IKLOOP2: do ik = k1, k2
-
-              if ((za(il,ij,ik) > pbl(il,ij)) .and. (ik /= k1)) then
-!               ============
-                exit IKLOOP2
-!               ============
-              end if
-
-!             -----
-!             Dust.
-!             -----
-
-              if (emiss_dust_opt /= 0) then
-                do icx = 1, ndust
-
-                  ic = emiss_map_dust(icx)
-
-! Bigyani's correction
-!                 if (mass_pbl(il,ij) .le. 1.e-20)then
-!                    mass_pbl(il,ij) = 1.e-10
-!                 endif
-! End Bigyani's correction
-
-                  if (do_aerocom)then
-                     if ((ic /= INDMS) .and. (ik == k1)) then
-                       concentration(ic)%pArray3D(il,ij,ik) =  &
-     &                   concentration(ic)%pArray3D(il,ij,ik) +  &
-     &                     emiss_dust(il,ij,icx) * tdt/ mass(il,ij,ik)
-                     endif
-                  else
-                     concentration(ic)%pArray3D(il,ij,ik) =  &
-     &                 concentration(ic)%pArray3D(il,ij,ik) +  &
-     &                 emiss_dust(il,ij,icx) * tdt / mass_pbl(il,ij)
-                  end if
-
-                end do
-              end if
-
-!             ------------------------------
-!             Other aerosol (carbon & sslt).
-!             ------------------------------
-
-              if (emiss_aero_opt /= 0) then
-                do icx = 1, naero
-
-                  ic = emiss_map_aero(icx)
-
-                  if ((ic == IBOC) .or. (ic == IBBC)) then
-
-                    concentration(ic)%pArray3D(il,ij,ik) =  &
-     &                concentration(ic)%pArray3D(il,ij,ik) +  &
-     &                emiss_aero(il,ij,icx) * tdt / mass_pbl(il,ij)
-
-                  else if (((ic == INOC)   .or. (ic == IFOC)   .or.  &
-     &                      (ic == IFBC)   .or. (ic == ISSLT1) .or.  &
-     &                      (ic == ISSLT2) .or. (ic == ISSLT3) .or.  &
-     &                      (ic == ISSLT4)) .and.  &
-     &                     (ik == k1)) then
-
-                    concentration(ic)%pArray3D(il,ij,ik) =  &
-     &                concentration(ic)%pArray3D(il,ij,ik) +  &
-     &                emiss_aero(il,ij,icx) * tdt / mass(il,ij,ik)
-
-                  end if
-
-                end do
-              end if
-
-            end do IKLOOP2
-
-          end do
-        end do
-
-!     ======
-      end if
-!     ======
 
 
       return

--- a/GMI_GridComp/GmiForcingBC_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiForcingBC_GridCompClassMod.F90
@@ -563,7 +563,6 @@ CONTAINS
    USE GmiTimeControl_mod,            ONLY : Set_gmiSeconds, GetSecondsFromJanuary1
    USE GmiTimeControl_mod,            ONLY : Get_gmiSeconds, Get_begGmiDate
    USE GmiSpcConcentrationMethod_mod, ONLY : resetFixedConcentration
-   USE GmiSolar_mod,                  ONLY : CalcCosSolarZenithAngle
    use GmiUpdateForcingBC_mod       , only : updateForcingBC
 
    IMPLICIT none

--- a/GMI_GridComp/GmiPhotolysis_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiPhotolysis_GridCompClassMod.F90
@@ -1148,8 +1148,9 @@ CONTAINS
    USE GmiTimeControl_mod,            ONLY : Set_gmiSeconds, GetSecondsFromJanuary1
    USE GmiTimeControl_mod,            ONLY : GetDaysFromJanuary1, ConvertTimeToSeconds
    USE GmiSpcConcentrationMethod_mod, ONLY : resetFixedConcentration
-   USE GmiSolar_mod,                  ONLY : computeSolarZenithAngle_Photolysis
    USE GmiPhotRateConst_mod,          ONLY : calcPhotolysisRateConstants
+
+   USE SZA_from_MAPL_mod,             ONLY : compute_SZA
 
    IMPLICIT none
 
@@ -1237,8 +1238,6 @@ CONTAINS
    INTEGER, PARAMETER :: ToGMI = 1
    INTEGER, PARAMETER :: FromGMI = -1
 
-   REAL :: pi,degToRad,radToDeg,OneOverDt
-
    REAL, PARAMETER :: mwtAir = 28.9
    REAL, PARAMETER :: rStar = 8.314E+03
    REAL, PARAMETER :: Pa2hPa = 0.01
@@ -1292,23 +1291,9 @@ CONTAINS
    REAL(KIND=DBL), ALLOCATABLE :: ri_(:,:,:)
    REAL(KIND=DBL), ALLOCATABLE :: rl_(:,:,:)
 
-! VV adding Mike's MAPL SZA edits
-   REAL          , ALLOCATABLE ::  ZTH(:,:)
-   REAL          , ALLOCATABLE ::  SLR(:,:)
-   REAL          , ALLOCATABLE :: ZTHP(:,:)
 
    REAL(KIND=DBL), ALLOCATABLE :: solarZenithAngle(:,:)
 
-   TYPE (ESMF_TimeInterval)    ::  GMI_timestep
-   TYPE (ESMF_TimeInterval)    :: MAPL_timestep
-   TYPE (ESMF_Time)            :: CURRENTTIME
-   TYPE (ESMF_Time)            :: SZA_start_time   ! compute average SZA starting at this time
-   TYPE (ESMF_Time)            :: SZA_midpoint
-
-   LOGICAL :: verbose_time   ! To see details on SZA time averaging
-
-   verbose_time = .FALSE.
- 
    loc_proc = -99
 
 !  Grid specs
@@ -1339,11 +1324,7 @@ CONTAINS
 
 !  Some real constants
 !  -------------------
-   pi = 4.00*ATAN(1.00)
-   degToRad = pi/180.00
-   radToDeg = 180.00/pi
    chemDt = tdt
-   OneOverDt = 1.00/tdt
 
    rootProc=.FALSE.
    IF( MAPL_AM_I_ROOT() ) THEN
@@ -1386,17 +1367,7 @@ CONTAINS
    ALLOCATE(               ri_(i1:i2,j1:j2,1:km), __STAT__ )
    ALLOCATE(               rl_(i1:i2,j1:j2,1:km), __STAT__ )
 
-   ALLOCATE(               ZTH(i1:i2,j1:j2), &
-                           SLR(i1:i2,j1:j2), &
-                          ZTHP(i1:i2,j1:j2),     __STAT__ )
-
    
-
-! Geolocation
-! -----------
-!   lonDeg(i1:i2,j1:j2)=self%lonRad(i1:i2,j1:j2)*radToDeg !VV adding Mike's MAPL SZA
-!   latDeg(i1:i2,j1:j2)=self%latRad(i1:i2,j1:j2)*radToDeg
-
 !  Layer mean pressures. NOTE: ple(:,:,0:km)
 !  -----------------------------------------
    DO k=1,km
@@ -1462,85 +1433,10 @@ CONTAINS
 
       IF (self%gotImportRst) THEN
         if (self%phot_opt == 3) then
-! GMI routine, provided SZA > 90
-!         if ((self%phot_opt == 3) then 
 
-!            call GetSecondsFromJanuary1 (nsec_jan1, nymd, nhms)
-
-!            call GetDaysFromJanuary1 (jday, nymd)
-!            time_sec = ConvertTimeToSeconds (nhms)
-
-!            solarZenithAngle(i1:i2,j1:j2) = &
-!                 computeSolarZenithAngle_Photolysis (jday, time_sec, &
-!                          self%fastj_offset_sec, latDeg, lonDeg, i1, i2, j1, j2)
-
-! MEM 6.30.20
-!     Now get the SZA using a MAPL call:
-
-          call ESMF_ClockGet(self%clock, TIMESTEP=MAPL_timestep, currTIME=CURRENTTIME, __RC__ )
-
-          IF( verbose_time .AND. MAPL_AM_I_ROOT() ) THEN
-
-            call ESMF_TimePrint(CURRENTTIME, preString="CURRENTTIME = ", __RC__ )
-
-            print *, "MAPL_timestep = "
-            call ESMF_TimeIntervalPrint(MAPL_timestep, options="string", __RC__ )
-
-          ENDIF
-
-          call ESMF_TimeIntervalSet(GMI_timestep, s=INT(tdt+0.1), __RC__ )
-
-          IF( verbose_time .AND. MAPL_AM_I_ROOT() ) THEN
-
-            print *, "GMI_timestep = "
-            call ESMF_TimeIntervalPrint(GMI_timestep, options="string", __RC__ )
-
-            print *, "computing Photolysis w/ tdt = ", tdt
-
-          ENDIF
-
-          ! We want a starting time = MAPL time + 1/2 MAPL timestep - 1/2 GMI timestep
-          ! We want a time interval == GMI timestep
-
-          ! Position SZA_midpoint to be midpoint of MAPL_timestep
-          SZA_midpoint = CURRENTTIME + (MAPL_timestep/2)
-
-          ! Position SZA_start_time to be half of a GMI timestep earlier
-          SZA_start_time = SZA_midpoint - (GMI_timestep/2)
-
-          IF( verbose_time .AND. MAPL_AM_I_ROOT() ) THEN
-            call ESMF_TimePrint(SZA_start_time,              preString="SZA averaging start_time = ", __RC__ )
-            call ESMF_TimePrint(SZA_start_time+GMI_timestep, preString="SZA averaging   end_time = ", __RC__ )
-          ENDIF
-
-! Calling sequence from SOLAR GridComp:
-!     call MAPL_SunGetInsolation(   &
-!             self%lonRad,          &    !  from the MAPL_Get  REAL, pointer, (IM,JM)
-!             self%latRad,          &    !  from the MAPL_Get  REAL, pointer, (IM,JM)
-!             self%orbit,           &    !  from MAPL_Get      type (MAPL_SunOrbit)
-!             ZTH,                  &    !  OUT                REAL,          (IM,JM)
-!             SLR,                  &    !  OUT                REAL,          (IM,JM)
-!             INTV = MAPL_timestep, &    !  INOUT              type (ESMF_TimeInterval)
-!                                   &    !   the CLOCK timestep    [optional]   Why INOUT?
-!             CLOCK = self%clock,   &    !  IN   [optional]    type(ESMF_Clock)
-!         !   TIME = SUNFLAG,       &    !  IN   [optional]    INTEGER
-!         !   ZTHN = ZTHN,          &    !  OUT  [optional]    REAL,          (IM,JM )
-!             ZTHP = ZTHP,          &    !  OUT  [optional]    REAL,          (IM,JM)
-!             RC=STATUS )
-!     VERIFY_(STATUS)
-
-          call MAPL_SunGetInsolation(        &
-                  self%lonRad,               &
-                  self%latRad,               &
-                  self%orbit,                &
-                  ZTH,                       &
-                  SLR,                       &
-                  CURRTIME = SZA_start_time, &
-                  INTV     = GMI_timestep,   &
-                  ZTHP     = ZTHP,           &
-                  __RC__ )
-
-          solarZenithAngle(i1:i2,j1:j2) = ACOS( ZTHP ) * radToDeg
+          call compute_SZA ( LONS=self%lonRad, LATS=self%latRad, ORBIT=self%orbit, &
+                             CLOCK=self%clock, tdt=tdt, label='GMI-PHOT', &
+                             SZA=solarZenithAngle, __RC__ )
 
           call calcPhotolysisRateConstants (self%JXbundle,                     &
                      tropopausePress,                         &
@@ -1596,7 +1492,7 @@ CONTAINS
               moistq, STAT=STATUS)
    VERIFY_(STATUS)
 
-   DEALLOCATE(tau_clw, tau_cli, qi_, ql_, ri_, rl_, ZTH, SLR, ZTHP, STAT=STATUS)
+   DEALLOCATE(tau_clw, tau_cli, qi_, ql_, ri_, rl_, STAT=STATUS)
    VERIFY_(STATUS)
 
 ! IMPORTANT: Reset this switch to .TRUE. after first pass.

--- a/GMI_GridComp/GmiPhotolysis_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiPhotolysis_GridCompClassMod.F90
@@ -86,14 +86,6 @@
 ! -------------------------------------------------
    LOGICAL :: BCRealTime
 
-! Switches for coupling with GOCART dust and aerosols
-! ---------------------------------------------------
-   LOGICAL :: usingGOCART_BC
-   LOGICAL :: usingGOCART_DU
-   LOGICAL :: usingGOCART_OC
-   LOGICAL :: usingGOCART_SS
-   LOGICAL :: usingGOCART_SU
-
 ! Perhaps GMICHEM is the AERO_PROVIDER
 ! ------------------------------------
    LOGICAL :: AM_I_AERO_PROVIDER    ! Even if another GC is the real AERO_PROVIDER, set this TRUE to have GMI export the AERO state, etc.
@@ -724,53 +716,17 @@ CONTAINS
      &                default = hugeReal, rc=STATUS )
       VERIFY_(STATUS)
 
-      ! ----------------------------------------
-      ! Do we want to couple to GOCART aerosols?
-      ! ----------------------------------------
-      
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%usingGOCART_BC, &
-     &           label="usingGOCART_BC:", default=.false., rc=STATUS)
-      VERIFY_(STATUS)
-      
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%usingGOCART_DU, &
-     &           label="usingGOCART_DU:", default=.false., rc=STATUS)
-      VERIFY_(STATUS)
-      
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%usingGOCART_OC, &
-     &           label="usingGOCART_OC:", default=.false., rc=STATUS)
-      VERIFY_(STATUS)
-      
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%usingGOCART_SS, &
-     &           label="usingGOCART_SS:", default=.false., rc=STATUS)
-      VERIFY_(STATUS)
-      
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%usingGOCART_SU, &
-     &           label="usingGOCART_SU:", default=.false., rc=STATUS)
-      VERIFY_(STATUS)
-
-
-   IF( MAPL_AM_I_ROOT() ) THEN
-    PRINT *," "
-    PRINT *,TRIM(IAm)//":"
-    PRINT *," Using GOCART   Black Carbon: ",self%usingGOCART_BC
-    PRINT *," Using GOCART           Dust: ",self%usingGOCART_DU
-    PRINT *," Using GOCART Organic Carbon: ",self%usingGOCART_OC
-    PRINT *," Using GOCART       Sea Salt: ",self%usingGOCART_SS
-    PRINT *," Using GOCART        Sulfate: ",self%usingGOCART_SU
-    PRINT *," "
-   END IF
 
 ! Perform consistency checks for aerosols
 ! ---------------------------------------
    IF(self%AM_I_AERO_PROVIDER) THEN
-    IF(self%usingGOCART_BC .OR. self%usingGOCART_DU .OR. self%usingGOCART_OC .OR. &
-       self%usingGOCART_SS .OR. self%usingGOCART_SU) THEN
+    IF (TRIM(self%aeroProviderName) == 'GOCART2G') THEN 
      STATUS = 1
      IF( MAPL_AM_I_ROOT() ) THEN
       PRINT *," "
       PRINT *,TRIM(IAm)//":"
       PRINT *," AM_I_AERO_PROVIDER: ",self%AM_I_AERO_PROVIDER
-      PRINT *," Cannot couple GOCART aerosols to GMICHEM when GMICHEM is the AERO_PROVIDER"
+      PRINT *," Cannot couple GOCART2G aerosols to GMICHEM when GMICHEM is the AERO_PROVIDER"
      END IF
      VERIFY_(STATUS)
     END IF
@@ -1203,6 +1159,37 @@ CONTAINS
    REAL, POINTER, DIMENSION(:,:,:) :: rl => NULL()
    REAL, POINTER, DIMENSION(:,:,:) :: rh2,dqdt
 
+
+! Adding GOCART2G fields from AERO BUNDLE
+! ---------------------------------------
+   type(ESMF_State)   :: aero_state
+   type(ESMF_State)   :: bc_state
+   type(ESMF_State)   :: oc_state
+   type(ESMF_State)   :: br_state
+   type(ESMF_State)   :: su_state
+   type(ESMF_State)   :: du_state
+   type(ESMF_State)   :: ss_state
+
+   type(ESMF_Field)   :: bc_phobic_3d_field
+   type(ESMF_Field)   :: bc_philic_3d_field
+   type(ESMF_Field)   :: oc_phobic_3d_field
+   type(ESMF_Field)   :: oc_philic_3d_field
+   type(ESMF_Field)   :: br_phobic_3d_field
+   type(ESMF_Field)   :: br_philic_3d_field
+   type(ESMF_Field)   ::       so4_3d_field
+   type(ESMF_Field)   ::        du_4d_field
+   type(ESMF_Field)   ::        ss_4d_field
+
+   real, pointer, dimension(:,:,:)   :: bc_phobic_3d_array
+   real, pointer, dimension(:,:,:)   :: bc_philic_3d_array
+   real, pointer, dimension(:,:,:)   :: oc_phobic_3d_array
+   real, pointer, dimension(:,:,:)   :: oc_philic_3d_array
+   real, pointer, dimension(:,:,:)   :: br_phobic_3d_array
+   real, pointer, dimension(:,:,:)   :: br_philic_3d_array
+   real, pointer, dimension(:,:,:)   ::       so4_3d_array
+   real, pointer, dimension(:,:,:,:) ::        du_4d_array
+   real, pointer, dimension(:,:,:,:) ::        ss_4d_array
+
 !  Dust and aerosols.  May serve as imports from GOCART
 !  or as exports to fill the AERO_BUNDLE, but not both.
 !  ----------------------------------------------------
@@ -1382,6 +1369,18 @@ CONTAINS
    CALL Set_numTimeSteps(self%gmiClock, ic+1)
    CALL Set_gmiSeconds(self%gmiClock, (ic+1)*chemDt)
 
+   IF ( TRIM(self%aeroProviderName) .EQ. "GOCART2G" ) THEN
+! Get the AERO state and individual Aerosol states
+! ------------------------------------------------
+      call ESMF_StateGet(impChem, 'AERO', aero_state, __RC__)
+      call ESMF_StateGet(aero_state, 'CA.bc_AERO', bc_state, __RC__)
+      call ESMF_StateGet(aero_state, 'CA.oc_AERO', oc_state, __RC__)
+      call ESMF_StateGet(aero_state, 'CA.br_AERO', br_state, __RC__)
+      call ESMF_StateGet(aero_state,    'SU_AERO', su_state, __RC__)
+      call ESMF_StateGet(aero_state,    'DU_AERO', du_state, __RC__)
+      call ESMF_StateGet(aero_state,    'SS_AERO', ss_state, __RC__)
+   END IF
+
 ! Update the following time-dependent boundary conditions:
 !  Fixed concentration species
 !  Stratospheric sulfate surface area
@@ -1533,53 +1532,26 @@ CONTAINS
   REAL, POINTER, DIMENSION(:,:,:) :: PTR3D
   REAL :: qmin,qmax
   
-  TYPE(ESMF_State)           :: aero
-  TYPE(ESMF_FieldBundle)     :: aerosols
-
   rc = 0
   IAm = "Acquire_BC"
 
   SELECT CASE (TRIM(self%aeroProviderName))
 
-   CASE("GOCART.data")
+   CASE("GOCART2G")
 
-    CALL ESMF_StateGet(impChem, 'AERO', aero, RC=STATUS)
-    VERIFY_(STATUS)
-    CALL ESMF_StateGet(aero, 'AEROSOLS', aerosols, RC=STATUS)
-    VERIFY_(STATUS)
+    call ESMF_StateGet(bc_state, 'CA.bcphobic', bc_phobic_3d_field, __RC__)
+    call ESMF_StateGet(bc_state, 'CA.bcphilic', bc_philic_3d_field, __RC__)
 
-    CALL ESMFL_BundleGetPointertoData(aerosols, 'BCphobic', PTR3D, RC=STATUS)
-    VERIFY_(STATUS)
-    self%dAersl(:,:,km:1:-1,1) = PTR3D(:,:,1:km)*airdens(:,:,1:km)
-    IF(self%verbose) CALL pmaxmin('BCphobic:', PTR3D, qmin, qmax, iXj, km, 1. )
-    NULLIFY(PTR3D)
+    call ESMF_FieldGet( field=bc_phobic_3d_field, farrayPtr=bc_phobic_3d_array, __RC__ )
+    call ESMF_FieldGet( field=bc_philic_3d_field, farrayPtr=bc_philic_3d_array, __RC__ )
 
-    CALL ESMFL_BundleGetPointertoData(aerosols, 'BCphilic', PTR3D, RC=STATUS)
-    VERIFY_(STATUS)
-    self%wAersl(:,:,km:1:-1,2) = PTR3D(:,:,1:km)*airdens(:,:,1:km)
-    IF(self%verbose) CALL pmaxmin('BCphilic:', PTR3D, qmin, qmax, iXj, km, 1. )
-    NULLIFY(PTR3D)
+    self%dAersl(:,:,km:1:-1,1) = bc_phobic_3d_array(:,:,1:km)*airdens(:,:,1:km)
+    self%wAersl(:,:,km:1:-1,2) = bc_philic_3d_array(:,:,1:km)*airdens(:,:,1:km)
 
-
-   CASE("GOCART")
-
-    IF(self%usingGOCART_BC) THEN
-
-     CALL MAPL_GetPointer(impChem, BCphobic, 'GOCART::BCphobic', RC=STATUS)
-     VERIFY_(STATUS)
-     CALL MAPL_GetPointer(impChem, BCphilic, 'GOCART::BCphilic', RC=STATUS)
-     VERIFY_(STATUS)
-
-     self%dAersl(:,:,km:1:-1,1) = BCphobic(:,:,1:km)*airdens(:,:,1:km)
-     self%wAersl(:,:,km:1:-1,2) = BCphilic(:,:,1:km)*airdens(:,:,1:km)
-
-     IF(self%verbose) THEN
-      CALL pmaxmin('BCphobic:', BCphobic, qmin, qmax, iXj, km, 1. )
-      CALL pmaxmin('BCphilic:', BCphilic, qmin, qmax, iXj, km, 1. )
-     END IF
-
+    IF(self%verbose) THEN
+     CALL MAPL_MaxMin('BCphobic:', bc_phobic_3d_array)
+     CALL MAPL_MaxMin('BCphilic:', bc_philic_3d_array)
     END IF
-
 
    CASE("GMICHEM")
 
@@ -1715,79 +1687,38 @@ CONTAINS
   REAL, POINTER, DIMENSION(:,:,:) :: PTR3D
   REAL :: qmin,qmax
   
-  TYPE(ESMF_State)           :: aero
-  TYPE(ESMF_FieldBundle)     :: aerosols
-
   rc = 0
   IAm = "Acquire_DU"
 
   SELECT CASE (TRIM(self%aeroProviderName))
 
-   CASE("GOCART.data")
+   CASE("GOCART2G")
 
-    CALL ESMF_StateGet(impChem, 'AERO', aero, RC=STATUS)
-    VERIFY_(STATUS)
-    CALL ESMF_StateGet(aero, 'AEROSOLS', aerosols, RC=STATUS)
-    VERIFY_(STATUS)
-
-    CALL ESMFL_BundleGetPointertoData(aerosols, 'du001', PTR3D, RC=STATUS)
-    VERIFY_(STATUS)
-    self%dust(:,:,km:1:-1,1) = PTR3D(:,:,1:km)*airdens(:,:,1:km)*0.009
-    self%dust(:,:,km:1:-1,2) = PTR3D(:,:,1:km)*airdens(:,:,1:km)*0.081
-    self%dust(:,:,km:1:-1,3) = PTR3D(:,:,1:km)*airdens(:,:,1:km)*0.234
-    self%dust(:,:,km:1:-1,4) = PTR3D(:,:,1:km)*airdens(:,:,1:km)*0.676
-    IF(self%verbose) CALL pmaxmin('du001:', PTR3D, qmin, qmax, iXj, km, 1. )
-    NULLIFY(PTR3D)
-
-    CALL ESMFL_BundleGetPointertoData(aerosols, 'du002', PTR3D, RC=STATUS)
-    VERIFY_(STATUS)
-    self%dust(:,:,km:1:-1,5) = PTR3D(:,:,1:km)*airdens(:,:,1:km)
-    IF(self%verbose) CALL pmaxmin('du002:', PTR3D, qmin, qmax, iXj, km, 1. )
-    NULLIFY(PTR3D)
-
-    CALL ESMFL_BundleGetPointertoData(aerosols, 'du003', PTR3D, RC=STATUS)
-    VERIFY_(STATUS)
-    self%dust(:,:,km:1:-1,6) = PTR3D(:,:,1:km)*airdens(:,:,1:km)
-    IF(self%verbose) CALL pmaxmin('du003:', PTR3D, qmin, qmax, iXj, km, 1. )
-    NULLIFY(PTR3D)
-
-    CALL ESMFL_BundleGetPointertoData(aerosols, 'du004', PTR3D, RC=STATUS)
-    VERIFY_(STATUS)
-    self%dust(:,:,km:1:-1,7) = PTR3D(:,:,1:km)*airdens(:,:,1:km)
-    IF(self%verbose) CALL pmaxmin('du004:', PTR3D, qmin, qmax, iXj, km, 1. )
-    NULLIFY(PTR3D)
-
-
-   CASE("GOCART")
-
-    IF(self%usingGOCART_DU) THEN
-
-     CALL MAPL_GetPointer(impChem, DU001, 'GOCART::du001', RC=STATUS)
-     VERIFY_(STATUS)
-     CALL MAPL_GetPointer(impChem, DU002, 'GOCART::du002', RC=STATUS)
-     VERIFY_(STATUS)
-     CALL MAPL_GetPointer(impChem, DU003, 'GOCART::du003', RC=STATUS)
-     VERIFY_(STATUS)
-     CALL MAPL_GetPointer(impChem, DU004, 'GOCART::du004', RC=STATUS)
-     VERIFY_(STATUS)
-
-     IF(self%verbose) THEN
-      CALL pmaxmin('DU001:', DU001, qmin, qmax, iXj, km, 1. )
-      CALL pmaxmin('DU002:', DU002, qmin, qmax, iXj, km, 1. )
-      CALL pmaxmin('DU003:', DU003, qmin, qmax, iXj, km, 1. )
-      CALL pmaxmin('DU004:', DU004, qmin, qmax, iXj, km, 1. )
-     END IF
-
-     self%dust(:,:,km:1:-1,1) = DU001(:,:,1:km)*airdens(:,:,1:km)*0.009
-     self%dust(:,:,km:1:-1,2) = DU001(:,:,1:km)*airdens(:,:,1:km)*0.081
-     self%dust(:,:,km:1:-1,3) = DU001(:,:,1:km)*airdens(:,:,1:km)*0.234
-     self%dust(:,:,km:1:-1,4) = DU001(:,:,1:km)*airdens(:,:,1:km)*0.676
-     self%dust(:,:,km:1:-1,5) = DU002(:,:,1:km)*airdens(:,:,1:km)
-     self%dust(:,:,km:1:-1,6) = DU003(:,:,1:km)*airdens(:,:,1:km)
-     self%dust(:,:,km:1:-1,7) = DU004(:,:,1:km)*airdens(:,:,1:km)
-
+    ! 'DU' 5 'bin' dimensions, kg kg-1 mass mixing ratio, top-down
+    call ESMF_StateGet(du_state,     'DU',           du_4d_field, __RC__)  ! note: 4-D
+    call ESMF_FieldGet(field=du_4d_field, farrayPtr=du_4d_array, __RC__ )  ! note: 4-D
+    
+    ! Create DU001-4 from DU bin dimension
+    DU001 => du_4d_array(:,:,1:km,1)
+    DU002 => du_4d_array(:,:,1:km,2)
+    DU003 => du_4d_array(:,:,1:km,3)
+    DU004 => du_4d_array(:,:,1:km,4)
+     
+    IF(self%verbose) THEN
+     CALL MAPL_MaxMin('DU001:', DU001)
+     CALL MAPL_MaxMin('DU002:', DU002)
+     CALL MAPL_MaxMin('DU003:', DU003)
+     CALL MAPL_MaxMin('DU004:', DU004)
     END IF
 
+    ! then create dust with the 7 bins created from the 4 dust bins
+    self%dust(:,:,km:1:-1,1) = DU001(:,:,1:km)*airdens(:,:,1:km)*0.009
+    self%dust(:,:,km:1:-1,2) = DU001(:,:,1:km)*airdens(:,:,1:km)*0.081
+    self%dust(:,:,km:1:-1,3) = DU001(:,:,1:km)*airdens(:,:,1:km)*0.234
+    self%dust(:,:,km:1:-1,4) = DU001(:,:,1:km)*airdens(:,:,1:km)*0.676
+    self%dust(:,:,km:1:-1,5) = DU002(:,:,1:km)*airdens(:,:,1:km)
+    self%dust(:,:,km:1:-1,6) = DU003(:,:,1:km)*airdens(:,:,1:km)
+    self%dust(:,:,km:1:-1,7) = DU004(:,:,1:km)*airdens(:,:,1:km)
 
    CASE("GMICHEM")
 
@@ -1905,54 +1836,36 @@ CONTAINS
   REAL, POINTER, DIMENSION(:,:,:) :: PTR3D
   REAL :: qmin,qmax
   
-  TYPE(ESMF_State)           :: aero
-  TYPE(ESMF_FieldBundle)     :: aerosols
-  TYPE(ESMF_StateItem_Flag)  :: itemtype
-
   rc = 0
   IAm = "Acquire_OC"
 
   SELECT CASE (TRIM(self%aeroProviderName))
 
-   CASE("GOCART.data")
+   CASE("GOCART2G")
+    
+    call ESMF_StateGet(oc_state, 'CA.ocphobic', oc_phobic_3d_field, __RC__)
+    call ESMF_StateGet(oc_state, 'CA.ocphilic', oc_philic_3d_field, __RC__)
+    call ESMF_StateGet(br_state, 'CA.brphobic', br_phobic_3d_field, __RC__)
+    call ESMF_StateGet(br_state, 'CA.brphilic', br_philic_3d_field, __RC__)
 
-    CALL ESMF_StateGet(impChem, 'AERO', aero, RC=STATUS)
-    VERIFY_(STATUS)
-    CALL ESMF_StateGet(aero, 'AEROSOLS', aerosols, RC=STATUS)
-    VERIFY_(STATUS)
+    call ESMF_FieldGet( field=oc_phobic_3d_field, farrayPtr=oc_phobic_3d_array, __RC__ )
+    call ESMF_FieldGet( field=oc_philic_3d_field, farrayPtr=oc_philic_3d_array, __RC__ )
+    call ESMF_FieldGet( field=br_phobic_3d_field, farrayPtr=br_phobic_3d_array, __RC__ )
+    call ESMF_FieldGet( field=br_philic_3d_field, farrayPtr=br_philic_3d_array, __RC__ )
 
-    CALL ESMFL_BundleGetPointertoData(aerosols, 'OCphobic', PTR3D, RC=STATUS)
-    VERIFY_(STATUS)
-    self%dAersl(:,:,km:1:-1,2) = PTR3D(:,:,1:km)*airdens(:,:,1:km)
-    IF(self%verbose) CALL pmaxmin('OCphobic:', PTR3D, qmin, qmax, iXj, km, 1. )
-    NULLIFY(PTR3D)
+    self%dAersl(:,:,km:1:-1,2) = oc_phobic_3d_array(:,:,1:km)*airdens(:,:,1:km)
+    self%wAersl(:,:,km:1:-1,3) = oc_philic_3d_array(:,:,1:km)*airdens(:,:,1:km)
 
-    CALL ESMFL_BundleGetPointertoData(aerosols, 'OCphilic', PTR3D, RC=STATUS)
-    VERIFY_(STATUS)
-    self%wAersl(:,:,km:1:-1,3) = PTR3D(:,:,1:km)*airdens(:,:,1:km)
-    IF(self%verbose) CALL pmaxmin('OCphilic:', PTR3D, qmin, qmax, iXj, km, 1. )
-    NULLIFY(PTR3D)
+    !GOCART2G has brown carbon broken out 
+    self%dAersl(:,:,km:1:-1,2) = self%dAersl(:,:,km:1:-1,2)+br_phobic_3d_array(:,:,1:km)*airdens(:,:,1:km)
+    self%wAersl(:,:,km:1:-1,3) = self%wAersl(:,:,km:1:-1,3)+br_philic_3d_array(:,:,1:km)*airdens(:,:,1:km)
 
-
-   CASE("GOCART")
-
-    IF(self%usingGOCART_OC) THEN
-
-     CALL MAPL_GetPointer(impChem, OCphobic, 'GOCART::OCphobic', RC=STATUS)
-     VERIFY_(STATUS)
-     CALL MAPL_GetPointer(impChem, OCphilic, 'GOCART::OCphilic', RC=STATUS)
-     VERIFY_(STATUS)
-
-     self%dAersl(:,:,km:1:-1,2) = OCphobic(:,:,1:km)*airdens(:,:,1:km)
-     self%wAersl(:,:,km:1:-1,3) = OCphilic(:,:,1:km)*airdens(:,:,1:km)
-
-     IF(self%verbose) THEN
-      CALL pmaxmin('OCphobic:', OCphobic, qmin, qmax, iXj, km, 1. )
-      CALL pmaxmin('OCphilic:', OCphilic, qmin, qmax, iXj, km, 1. )
-     END IF
-
+    IF(self%verbose) THEN
+     CALL MAPL_MaxMin('OCphobic:', oc_phobic_3d_array)   
+     CALL MAPL_MaxMin('OCphilic:', oc_philic_3d_array)   
+     CALL MAPL_MaxMin('BRphobic:', br_phobic_3d_array)   
+     CALL MAPL_MaxMin('BRphilic:', br_philic_3d_array)   
     END IF
-
 
    CASE("GMICHEM")
 !... Organic Carbon hydrophobic
@@ -2041,85 +1954,40 @@ CONTAINS
   REAL, POINTER, DIMENSION(:,:,:) :: PTR3D
   REAL :: qmin,qmax
   
-  TYPE(ESMF_State)           :: aero
-  TYPE(ESMF_FieldBundle)     :: aerosols
-
   rc = 0
   IAm = "Acquire_SS"
 
   SELECT CASE (TRIM(self%aeroProviderName))
 
-   CASE("GOCART.data")
+   CASE("GOCART2G")
 
-    CALL ESMF_StateGet(impChem, 'AERO', aero, RC=STATUS)
-    VERIFY_(STATUS)
-    CALL ESMF_StateGet(aero, 'AEROSOLS', aerosols, RC=STATUS)
-    VERIFY_(STATUS)
+    ! 'SS' 5 'bin' dimensions, kg kg-1 mass mixing ratio, top-down
+    call ESMF_StateGet(ss_state,           'SS',    ss_4d_field, __RC__)  ! note: 4-D
+    call ESMF_FieldGet(field=ss_4d_field, farrayPtr=ss_4d_array, __RC__)  ! note: 4-D
 
-    CALL ESMFL_BundleGetPointertoData(aerosols, 'ss001', PTR3D, RC=STATUS)
-    VERIFY_(STATUS)
-    self%wAersl(:,:,km:1:-1,4) = PTR3D(:,:,1:km)*airdens(:,:,1:km)
-    IF(self%verbose) CALL pmaxmin('ss001:', PTR3D, qmin, qmax, iXj, km, 1. )
-    NULLIFY(PTR3D)
-
-    CALL ESMFL_BundleGetPointertoData(aerosols, 'ss002', PTR3D, RC=STATUS)
-    VERIFY_(STATUS)
-    self%wAersl(:,:,km:1:-1,4) = self%wAersl(:,:,km:1:-1,4)+PTR3D(:,:,1:km)*airdens(:,:,1:km)
-    IF(self%verbose) CALL pmaxmin('ss002:', PTR3D, qmin, qmax, iXj, km, 1. )
-    NULLIFY(PTR3D)
-
-    CALL ESMFL_BundleGetPointertoData(aerosols, 'ss003', PTR3D, RC=STATUS)
-    VERIFY_(STATUS)
-    self%wAersl(:,:,km:1:-1,5) = PTR3D(:,:,1:km)*airdens(:,:,1:km)
-    IF(self%verbose) CALL pmaxmin('ss003:', PTR3D, qmin, qmax, iXj, km, 1. )
-    NULLIFY(PTR3D)
-
-    CALL ESMFL_BundleGetPointertoData(aerosols, 'ss004', PTR3D, RC=STATUS)
-    VERIFY_(STATUS)
-    self%wAersl(:,:,km:1:-1,5) = self%wAersl(:,:,km:1:-1,5)+PTR3D(:,:,1:km)*airdens(:,:,1:km)
-    IF(self%verbose) CALL pmaxmin('ss004:', PTR3D, qmin, qmax, iXj, km, 1. )
-    NULLIFY(PTR3D)
-
-    CALL ESMFL_BundleGetPointertoData(aerosols, 'ss005', PTR3D, RC=STATUS)
-    VERIFY_(STATUS)
-    self%wAersl(:,:,km:1:-1,5) = self%wAersl(:,:,km:1:-1,5)+PTR3D(:,:,1:km)*airdens(:,:,1:km)
-    IF(self%verbose) CALL pmaxmin('ss005:', PTR3D, qmin, qmax, iXj, km, 1. )
-    NULLIFY(PTR3D)
-
-
-   CASE("GOCART")
-
-    IF(self%usingGOCART_SS) THEN
-
-     CALL MAPL_GetPointer(impChem, SS001, 'GOCART::ss001', RC=STATUS)
-     VERIFY_(STATUS)
-     CALL MAPL_GetPointer(impChem, SS002, 'GOCART::ss002', RC=STATUS)
-     VERIFY_(STATUS)
-     CALL MAPL_GetPointer(impChem, SS003, 'GOCART::ss003', RC=STATUS)
-     VERIFY_(STATUS)
-     CALL MAPL_GetPointer(impChem, SS004, 'GOCART::ss004', RC=STATUS)
-     VERIFY_(STATUS)
-     CALL MAPL_GetPointer(impChem, SS005, 'GOCART::ss005', RC=STATUS)
-     VERIFY_(STATUS)
-
-     IF(self%verbose) THEN
-      CALL pmaxmin('SS001:', SS001, qmin, qmax, iXj, km, 1. )
-      CALL pmaxmin('SS002:', SS002, qmin, qmax, iXj, km, 1. )
-      CALL pmaxmin('SS003:', SS003, qmin, qmax, iXj, km, 1. )
-      CALL pmaxmin('SS004:', SS004, qmin, qmax, iXj, km, 1. )
-      CALL pmaxmin('SS005:', SS005, qmin, qmax, iXj, km, 1. )
-     END IF
+! Create SS001-5 from SS bin dimension 
+! ------------------------------------
+    SS001 => ss_4d_array(:,:,:,1)
+    SS002 => ss_4d_array(:,:,:,2)
+    SS003 => ss_4d_array(:,:,:,3)
+    SS004 => ss_4d_array(:,:,:,4)
+    SS005 => ss_4d_array(:,:,:,5)
+     
+    IF(self%verbose) THEN
+     CALL MAPL_MaxMin('SS001:', SS001)
+     CALL MAPL_MaxMin('SS002:', SS002)
+     CALL MAPL_MaxMin('SS003:', SS003)
+     CALL MAPL_MaxMin('SS004:', SS004)
+     CALL MAPL_MaxMin('SS005:', SS005)
+    END IF
 
 ! Accumulated
 ! -----------
-     self%wAersl(:,:,km:1:-1,4) = (SS001(:,:,1:km)+SS002(:,:,1:km))*airdens(:,:,1:km)
+    self%wAersl(:,:,km:1:-1,4) = (SS001(:,:,1:km)+SS002(:,:,1:km))*airdens(:,:,1:km)
 
 ! Coarse
 ! ------
-     self%wAersl(:,:,km:1:-1,5) = (SS003(:,:,1:km)+SS004(:,:,1:km)+SS005(:,:,1:km))*airdens(:,:,1:km)
-
-    END IF
-
+    self%wAersl(:,:,km:1:-1,5) = (SS003(:,:,1:km)+SS004(:,:,1:km)+SS005(:,:,1:km))*airdens(:,:,1:km)
 
    CASE("GMICHEM")
 
@@ -2232,8 +2100,6 @@ CONTAINS
   REAL, POINTER, DIMENSION(:,:,:) :: PTR3D
   REAL :: qmin,qmax
 
-  TYPE(ESMF_State)           :: aero
-  TYPE(ESMF_FieldBundle)     :: aerosols
   TYPE(ESMF_StateItem_Flag)  :: itemtype
 
   rc = 0
@@ -2241,50 +2107,33 @@ CONTAINS
 
   SELECT CASE (TRIM(self%aeroProviderName))
 
-   CASE("GOCART.data")
+   CASE("GOCART2G")
 
-    CALL ESMF_StateGet(impChem, 'AERO', aero, RC=STATUS)
-    VERIFY_(STATUS)
-    CALL ESMF_StateGet(aero, 'AEROSOLS', aerosols, RC=STATUS)
-    VERIFY_(STATUS)
+    call ESMF_StateGet(su_state,    'SO4',           so4_3d_field, __RC__)
+    call ESMF_FieldGet(field=so4_3d_field, farrayPtr=so4_3d_array, __RC__)
 
-    CALL ESMFL_BundleGetPointertoData(aerosols, 'SO4', PTR3D, RC=STATUS)
-    VERIFY_(STATUS)
-    self%wAersl(:,:,km:1:-1,1) = PTR3D(:,:,1:km)*airdens(:,:,1:km)
-    IF(self%verbose) CALL pmaxmin('SO4:', PTR3D, qmin, qmax, iXj, km, 1. )
-    NULLIFY(PTR3D)
+    self%wAersl(:,:,km:1:-1,1) = so4_3d_array(:,:,1:km)*airdens(:,:,1:km)
 
-
-   CASE("GOCART")
-
-    IF(self%usingGOCART_SU) THEN
-
-     CALL MAPL_GetPointer(impChem, SO4, 'GOCART::SO4', RC=STATUS)
-     VERIFY_(STATUS)
-     self%wAersl(:,:,km:1:-1,1) = SO4(:,:,1:km)*airdens(:,:,1:km)
-
-     IF(self%verbose) THEN
-      CALL pmaxmin('SO4:', SO4, qmin, qmax, iXj, km, 1. )
-     END IF
-
-     ! If volcanic SU exists, use it too:
-     CALL ESMF_StateGet(impChem, 'GOCART::SO4v', itemtype, RC=STATUS)
-     VERIFY_(STATUS)
-
-     IF ( itemtype == ESMF_STATEITEM_FIELD ) THEN
-       CALL MAPL_GetPointer(impChem, SO4, 'GOCART::SO4v', RC=STATUS)
-       VERIFY_(STATUS)
-
-       self%wAersl(:,:,km:1:-1,1) = &
-       self%wAersl(:,:,km:1:-1,1) + SO4(:,:,1:km)*airdens(:,:,1:km)
-
-       IF(self%verbose) THEN
-         CALL pmaxmin('SO4v:', SO4, qmin, qmax, iXj, km, 1. )
-       END IF
-     END IF
-
+    IF(self%verbose) THEN
+     CALL MAPL_MaxMin('SO4:', so4_3d_array)
     END IF
 
+ ! Currently, no volcanic SU exists, suggest ignoring by Pete 
+ ! ----------------------------------------------------------
+!     CALL ESMF_StateGet(impChem, 'SO4v', itemtype, RC=STATUS)
+!     VERIFY_(STATUS)
+  
+!     IF ( itemtype == ESMF_STATEITEM_FIELD ) THEN
+!       CALL MAPL_GetPointer(impChem, SO4, 'SO4v', RC=STATUS)
+!       VERIFY_(STATUS)
+
+!       self%wAersl(:,:,km:1:-1,1) = &
+!       self%wAersl(:,:,km:1:-1,1) + SO4(:,:,1:km)*airdens(:,:,1:km)
+
+!       IF(self%verbose) THEN
+!         CALL pmaxmin('SO4v:', SO4, qmin, qmax, iXj, km, 1. )
+!       END IF
+!     END IF
 
    CASE("GMICHEM")
 

--- a/GMI_GridComp/GmiSAD_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiSAD_GridCompClassMod.F90
@@ -643,7 +643,6 @@ CONTAINS
    USE GmiTimeControl_mod,            ONLY : Set_curGmiDate, Set_curGmiTime
    USE GmiTimeControl_mod,            ONLY : Set_numTimeSteps, Get_numTimeSteps
    USE GmiTimeControl_mod,            ONLY : Set_gmiSeconds, GetSecondsFromJanuary1
-   USE GmiSolar_mod,                  ONLY : CalcCosSolarZenithAngle
    USE GmiSpcConcentrationMethod_mod, ONLY : resetFixedConcentration
    USE GmiUpdateSAD_mod,              ONLY : updateSurfaceAreaDensities
 

--- a/GMI_GridComp/GmiThermalRC_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiThermalRC_GridCompClassMod.F90
@@ -509,7 +509,6 @@ CONTAINS
    USE GmiTimeControl_mod,            ONLY : Set_numTimeSteps, Get_numTimeSteps
    USE GmiTimeControl_mod,            ONLY : Set_gmiSeconds, GetSecondsFromJanuary1
    USE GmiSpcConcentrationMethod_mod, ONLY : resetFixedConcentration
-   USE GmiSolar_mod,                  ONLY : CalcCosSolarZenithAngle
    use GmiThermalRateConstants_mod  , only : calcThermalRateConstants
 
    IMPLICIT none

--- a/GMIchem_GridCompMod.F90
+++ b/GMIchem_GridCompMod.F90
@@ -305,6 +305,11 @@ CONTAINS
       STATUS = 0
 
 
+     CASE("CARMA")
+
+      STATUS = 0
+
+
      CASE("none")
 
       STATUS = 0
@@ -502,7 +507,7 @@ CONTAINS
 
 ! ========================== EXPORT STATE =========================
 
-    IF(TRIM(aeroProviderName) == "GMICHEM") THEN
+    IF(TRIM(aeroProviderName) == "GMICHEM" .or. TRIM(aeroProviderName) == "CARMA") THEN
 
 !   This state is needed by radiation, and contains aerosols and aerosol optics
 !   ---------------------------------------------------------------------------
@@ -1122,10 +1127,10 @@ CONTAINS
    CHARACTER(LEN=ESMF_MAXSTR)      :: providerName
    CHARACTER(LEN=ESMF_MAXSTR), POINTER, DIMENSION(:) :: fieldNames
 
-   INTEGER, PARAMETER :: numAeroes = 13
+   INTEGER, PARAMETER :: numAeroes = 15
    CHARACTER(LEN=ESMF_MAXSTR) :: aeroName(numAeroes) = (/"BCphobic","BCphilic", &
-             "du001   ","du002   ","du003   ","du004   ","OCphobic","OCphilic", &
-             "ss001   ","ss003   ","ss004   ","ss005   ","SO4     "/)
+             "du001   ","du002   ","du003   ","du004   ","du005   ","OCphobic","OCphilic", &
+             "ss001   ","ss002   ","ss003   ","ss004   ","ss005   ","SO4     "/)
 
    rc = 0
 
@@ -1167,7 +1172,7 @@ CONTAINS
    If (ESMF_UtilStringLowerCase(trim(ProviderName)).eq.'none') ProviderName = 'none'
 
    gcGMI%gcPhot%aeroProviderName = TRIM(ProviderName)
-   IF(TRIM(providerName) == "GMICHEM") THEN
+   IF(TRIM(providerName) == "GMICHEM" .or. TRIM(providerName) == "CARMA") THEN
     gcGMI%gcPhot%AM_I_AERO_PROVIDER = .TRUE.
    ELSE
     gcGMI%gcPhot%AM_I_AERO_PROVIDER = .FALSE.
@@ -1479,8 +1484,8 @@ CONTAINS
     CALL MAPL_StateAdd(aero, aeroBundle, __RC__)
 
     DO n = 1,numAeroes
-     CALL MAPL_GetPointer(expChem, PTR3D, "GMICHEM::"//TRIM(aeroName(n)), ALLOC=.TRUE., RC=STATUS)
-     CALL ESMF_StateGet(expChem, "GMICHEM::"//TRIM(aeroName(n)), field, __RC__)
+     CALL MAPL_GetPointer(expChem, PTR3D, TRIM(aeroName(n)), ALLOC=.TRUE., RC=STATUS)
+     CALL ESMF_StateGet(expChem, TRIM(aeroName(n)), field, __RC__)
      renamedField = MAPL_FieldCreate(field, NAME=TRIM(aeroName(n)), __RC__)
      CALL MAPL_FieldBundleAdd(aeroBundle, renamedField, __RC__)
      NULLIFY(PTR3D)
@@ -1505,7 +1510,7 @@ CONTAINS
      END IF
     END DO
 
-    CALL ESMF_MethodAdd(aero, LABEL='aerosol_optics', USERROUTINE=aerosol_optics, __RC__)
+    CALL ESMF_MethodAdd(aero, LABEL='run_aerosol_optics', USERROUTINE=aerosol_optics, __RC__)
 
     IF(MAPL_AM_I_ROOT()) THEN
      PRINT *," "
@@ -1789,7 +1794,7 @@ CONTAINS
 
 ! Replay mode detection
 ! ---------------------
-   CHARACTER(LEN=ESMF_MAXSTR)        :: ReplayMode
+   CHARACTER(LEN=ESMF_MAXSTR)        :: ReplayMode, H2SO4_Source
    TYPE(ESMF_Alarm)                  :: PredictorIsActive
    LOGICAL                           :: doingPredictorNow
 
@@ -2105,21 +2110,23 @@ CONTAINS
 
    END IF Phase99
 
-!.TEMP.. if H2SO4 exists in GMI then ZERO OUT H2SO4 until coupled into GOCART2G
-   SDSTEMP: IF ( phase == 2 .OR. phase == 99 ) THEN
+!... if H2SO4 exists in GMI then ZERO OUT H2SO4 unless coupled into SO4 altering aerosol component
+   H2SO4LOSS: IF ( phase == 2 .OR. phase == 99 ) THEN
      m = 1
      n = ggReg%nq
      iH2SO4 = -1
      DO i = m,n
-       IF(TRIM(ggReg%vname(i)) == "H2SO4") THEN
+       IF (TRIM(ggReg%vname(i)) == "H2SO4") THEN
          iH2SO4 = i
          EXIT
        ENDIF
      ENDDO
+!... 
      IF(iH2SO4 >= 1) THEN
-       bgg%qa(iH2SO4)%data3d(:,:,:) = 1e-30
+       call ESMF_ConfigGetAttribute(CF, H2SO4_Source, LABEL="SULFURIC_ACID_SOURCE:", DEFAULT='tendency', __RC__)
+       if (trim(H2SO4_Source).ne."full_field") bgg%qa(iH2SO4)%data3d(:,:,:) = 1e-30
      ENDIF
-   ENDIF SDSTEMP
+   ENDIF H2SO4LOSS
 
 
 !  Update age-of-air.
@@ -2872,7 +2879,7 @@ subroutine aerosol_optics(state, rc)
   end do
 
   call ESMF_AttributeGet(state, name='mie_table_instance', value=instance, __RC__)
-  call mie_(gocartMieTable(instance, aerosol_names, n_bands, offset, q_4d, rh, ext, ssa, asy, __RC__)
+  call mie_(gocartMieTable(instance), aerosol_names, n_bands, offset, q_4d, rh, ext, ssa, asy, __RC__)
 
   deallocate(dp, f_p, __STAT__)
 #else
@@ -2891,6 +2898,7 @@ subroutine aerosol_optics(state, rc)
   end do
 
   call mie_(gocartMieTable(instance), aerosol_names, n_bands, offset, q_4d, rh, ext, ssa, asy, __RC__)
+
 #endif
   
   call ESMF_AttributeGet(state, name='extinction_in_air_due_to_ambient_aerosol', value=fld_name, __RC__)

--- a/GMIchem_GridCompMod.F90
+++ b/GMIchem_GridCompMod.F90
@@ -299,6 +299,19 @@ CONTAINS
 							RC=STATUS  )
       VERIFY_(STATUS)
 
+     CASE("GOCART2G")
+!   GOCART2G aerosols and dust
+!   --------------------------
+
+      call MAPL_AddImportSpec(GC,                       &
+         short_name = 'AERO',                           &
+         long_name  = 'aerosol_mass_mixing_ratios_ng',  &
+         units      = 'kg kg-1',                        &
+         dims       = MAPL_DimsHorzVert,                &
+         vlocation  = MAPL_VLocationCenter,             &
+         RESTART    = MAPL_RestartSkip,                 &
+         datatype   = MAPL_StateItem, __RC__)
+
 
      CASE("GMICHEM")
 

--- a/GMIchem_GridCompMod.F90
+++ b/GMIchem_GridCompMod.F90
@@ -1358,6 +1358,8 @@ CONTAINS
    gcGMI%gcDepos%j2 = j2
    gcGMI%gcDepos%jm = jm
    gcGMI%gcDepos%km = km
+   gcGMI%gcDepos%orbit = ORBIT
+   gcGMI%gcDepos%clock = CLOCK
    
    gcGMI%gcEmiss%i1 = i1
    gcGMI%gcEmiss%i2 = i2
@@ -1383,7 +1385,7 @@ CONTAINS
    gcGMI%gcPhot%j2 = j2
    gcGMI%gcPhot%jm = jm
    gcGMI%gcPhot%km = km
-   gcGMI%gcPhot%orbit = ORBIT ! VV adding Mike's SZA edits
+   gcGMI%gcPhot%orbit = ORBIT
    gcGMI%gcPhot%clock = CLOCK
    
    gcGMI%gcSAD%i1 = i1


### PR DESCRIPTION
This PR is non-zero-diff for GMI simulations due to SZA.
Solar zenith angle had been computed locally for Emission and Deposition, but now SZA is
taken from MAPL, as had been done for Photolysis.  NOTE: this requires CHEMISTRY release v1.13.1 or later.

Aerosols from GOCART2G are now supported. Also, GMI can provide its own aerosols (via ExtData).

Details:
- Added capability for AERO_PROVIDER=GOCART2G
- Added capability for AERO_PROVIDER=GMICHEM
- Added capability for AERO_PROVIDER=CARMA (uses GMICHEM right now)
- Changed default aerosdust filename (for case AERO_PROVIDER=GMICHEM)
- Removed code that might have eventually run GOCART-like aerosols from within the GMI framework (note: doubtful this ever worked and would take significant effort to get working
- Instead of calling the Gmi routines for SZA (in Chem_Shared), now call a wrapper for the corresponding MAPL routine
