### PR TITLE
Edits from Benchmark G

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update CI to Baselibs 7.13.0
+- Changed a few SAD reactions to use JPL 2019 approach
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - QQJK diag calc had bug, used time(t+dt) constituents ibstead of time(t) fields, fixed on 2023Jul19
+- Fixed bug in Emissions and Deposition where SZA degrees was used instead of cosine(SZA)
+- Fixed units for degassing volcano point emissions
 
 ### Added
 
@@ -19,8 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update CI to Baselibs 7.13.0
-
-### Fixed
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update CI to Baselibs 7.13.0
 - Changed a few SAD reactions to use JPL 2019 approach
+- ExtData now uses Benchmark G configuration
+- Emissions including 2D, 3D and point source (volcano) now are done as in Benchmark G
+- Isoprene scaling changed from 1 to 0.7
+- Boundary condition file now includes HFCs, and no longer includes extra Br (when HFC mech is chosen)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - QQJK diag calc had bug, used time(t+dt) constituents ibstead of time(t) fields, fixed on 2023Jul19
 - Fixed bug in Emissions and Deposition where SZA degrees was used instead of cosine(SZA)
 - Fixed units for degassing volcano point emissions
+- Improved handling of phot_opt cases; allows for phot_opt == 0 again
+- Improved handling of sad_opt cases; allows for sad_opt == 0 again
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+### Added
+### Changed
+### Removed
+### Deprecated
+
+
+## [1.2.0] - 2023-12-07
 
 ### Fixed
 
@@ -28,10 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Emissions including 2D, 3D and point source (volcano) now are done as in Benchmark G
 - Isoprene scaling changed from 1 to 0.7
 - Boundary condition file now includes HFCs, and no longer includes extra Br (when HFC mech is chosen)
-
-### Removed
-
-### Deprecated
 
 
 ## [1.1.0] - 2023-04-24

--- a/GMI_GridComp/GMI_ExtData.yaml
+++ b/GMI_GridComp/GMI_ExtData.yaml
@@ -1,420 +1,262 @@
 Collections:
-  GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4:
-    template: ExtData/CMIP6/sfc/biomass_burning/CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
-  GMI_CMIP6_CEDS.airNOemis.x720_y360_z72_t12.%y4.nc4:
-    template: ExtData/CMIP6/L72/aircraft/CMIP6_CEDS.airNOemis.x720_y360_z72_t12.%y4.nc4
-  GMI_CMIP6_CEDS.airSO2emis.x720_y360_z72_t12.%y4.nc4:
-    template: ExtData/CMIP6/L72/CMIP6_CEDS.airSO2emis.x720_y360_z72_t12.%y4.nc4
-  GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4:
-    template: ExtData/CMIP6/sfc/fossil_fuels/CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
-  GMI_DMS_lana.geos.1x1.esmf.nc:
-    template: /discover/nobackup/cakelle2/data/OCEAN/DMS_lana.geos.1x1.esmf.nc
-  GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc:
-    template: ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-  GMI_OCS_vmr.x360_y181_z72.t12.2016.nc4:
-    template: ExtData/g5chem/L72/OCS_vmr.x360_y181_z72.t12.2016.nc4
-  GMI_SC.ODS.Emission.x360_y181.%y4.V1.nc:
-    template: /discover/nobackup/ssteenro/qing/SC.ODS.Emission.x360_y181.%y4.V1.nc
-  GMI_SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__energy_elevated.x720_y360_t12.%y4.nc:
-    template: ExtData/CMIP6/sfc/SU/SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__energy_elevated.x720_y360_t12.%y4.nc
-  GMI_SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__nonenergy_surface.x720_y360_t12.%y4.nc:
-    template: ExtData/CMIP6/sfc/SU/SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__nonenergy_surface.x720_y360_t12.%y4.nc
-  GMI_SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__shipping_surface.x720_y360_t12.%y4.nc:
-    template: ExtData/CMIP6/sfc/SU/SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__shipping_surface.x720_y360_t12.%y4.nc
-  GMI_SO2-em-biomassburning_input4MIPs_emissions_CMIP_VUA-CMIP-BB4CMIP6-1-2_gn__surface.x1440_y720_t12.%y4.nc:
-    template: ExtData/CMIP6/sfc/SU/SO2-em-biomassburning_input4MIPs_emissions_CMIP_VUA-CMIP-BB4CMIP6-1-2_gn__surface.x1440_y720_t12.%y4.nc
-  GMI_acetone_fixed_GMI.x288_y181_z72_t12.2001.nc:
-    template: ExtData/g5chem/L72/acetone_fixed_GMI.x288_y181_z72_t12.2001.nc
-  GMI_fertilizer_GMI.x288_y181_t12.2006.nc:
-    template: ExtData/g5chem/sfc/fertilizer_GMI.x288_y181_t12.2006.nc
-  GMI_lai_x720_y360_v72_t12_2008.nc:
-    template: ExtData/g5chem/sfc/LAI/lai_x720_y360_v72_t12_2008.nc
-  GMI_precipitation_GMI.x288_y181_t12.2006.nc:
-    template: ExtData/g5chem/sfc/precipitation_GMI.x288_y181_t12.2006.nc
-  GMI_sad_wt_CMIP6_288x181x72_%y4.nc:
-    template: ExtData/CMIP6/L72/SAD/sad_wt_CMIP6_288x181x72_%y4.nc
-  GMI_veg_fraction_x720_y360_t12_2008.nc:
-    template: ExtData/g5chem/sfc/LAI/veg_fraction_x720_y360_t12_2008.nc
-  GMI_aerodust_file:
-    template: ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4
+
+  ## As used in GOLF (benchmark G)
+  ## Adapted from RefD2
+  ## New FF dataset includes fugitive emissions
+
+  ## Monthly values
+
+  GMI.CH4_surf_values.clim:                            {                                                   template: /gpfsm/dnb33/mmanyin/CCM/run/aug2_GMI/aug2_GMI.test_ch4.20500315_1200z.nc4 }
+
+  GMI.CMIP6_BB.emis.monthly.1950-2015:                 { valid_range: "1950-01-16T00:00/2015-12-16T00:00", template: ExtData/CMIP6/sfc/biomass_burning/CMIP6_BB.emis.x1440_y720_t12.%y4.nc4 }
+  GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100:          { valid_range: "2015-01-16T00:00/2100-12-16T00:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/sfc/CMIP6_BB.ssp2_45.emis.x720_y360_t12.%y4.nc4 }
+
+  # note: 2014 file for SSP245 is actually a pointer to CEDS
+  #  GMI.CMIP6_CEDS.emis.monthly.1950-2014:            { valid_range: "1950-01-16T00:00/2014-12-16T00:00", template: ExtData/CMIP6/sfc/fossil_fuels/CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4 }
+  #  GMI.CMIP6_SSP245.emis.monthly.2014-2100:          { valid_range: "2014-01-16T00:00/2100-12-16T00:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/sfc/CMIP6_ssp2-45.emis.x720_y360_t12.%y4.nc4 }
+  GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014:            { valid_range: "1950-01-16T00:00/2014-12-16T00:00", template: /discover/nobackup/projects/gmao/ccmdev/mmanyin/bench/GOLF/INPUT/EMISS/CEDS_ff_plus_fugitive/CMIP6_CEDS.emis_fg.x720_y360_t12.%y4.nc4 }
+  GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100:          { valid_range: "2014-01-16T00:00/2100-12-16T00:00", template: /discover/nobackup/projects/gmao/ccmdev/mmanyin/bench/GOLF/INPUT/EMISS/SSP_ff_plus_fugitive/CMIP6_ssp2-45.emis_fg.x720_y360_t12.%y4.nc4 }
+
+  # note: 2014 file for SSP245 is actually a pointer to CEDS
+  GMI.CMIP6_CEDS_AirNO.emis.monthly.1950-2014:         { valid_range: "1950-01-15T12:00/2014-12-17T00:00", template: ExtData/CMIP6/L72/aircraft/CMIP6_CEDS.airNOemis.x720_y360_z72_t12.%y4.nc4 }
+  GMI.CMIP6_SSP245_AirNO.emis.monthly.2014-2100:       { valid_range: "2014-01-15T12:00/2100-12-17T00:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/L72/CMIP6_SSP245.airNOemis.x720_y360_z72_t12.%y4.nc4 }
+
+  # note: artificial dates for 2015-2023 dataset - it relaxes to the climatology
+  GMI.CMIP6_SAD.monthly.1850-2018:                     { valid_range: "1850-01-15T12:00/2018-12-17T00:00", template: ExtData/CMIP6/L72/SAD/sad_wt_CMIP6_288x181x72_%y4.nc }
+  GMI.CMIP6_SAD_shift_to_climo.monthly.2015-2023:      { valid_range: "2015-01-15T12:00/2023-12-17T00:00", template: /discover/nobackup/projects/gmao/ccmdev/input/GMIforcing/sad_wt_CMIP6_288x181x72_%y4.nc }
+  GMI.CMIP6_SAD.monthly_clim:                          { valid_range: "2000-01-15T12:00/2000-12-17T00:00", template: /discover/nobackup/projects/gmao/ccmdev/input/GMIforcing/sad_wt_CMIP6_288x181x72_clim.nc }  # 1850-2014 average
+
+  ## Monthly values needed for FLUX exports
+  ## (Previously these reverted to using 2020 as a climatology, after 2014)
+  ## (Now they continue with SSP2-4.5)
+
+  # note: 2014 file for SSP245 is actually a pointer to CEDS
+  GMI.CMIP6_CEDS_AirSO2.emis.monthly.1950-2014:        { valid_range: "1950-01-15T12:00/2014-12-17T00:00", template: ExtData/CMIP6/L72/CMIP6_CEDS.airSO2emis.x720_y360_z72_t12.%y4.nc4 }
+  GMI.CMIP6_SSP245_AirSO2.emis.monthly.2014-2100:      { valid_range: "2014-01-15T12:00/2100-12-17T00:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/L72/CMIP6_SSP245.airSO2emis.x720_y360_z72_t12.%y4.nc4 }
+
+  # note: 2014 file for SSP245 is actually a pointer to CEDS
+  GMI.CMIP_CEDS_SO2_ENERGY.emis.monthly.1950-2014:     { valid_range: "1950-01-15T00:00/2014-12-16T12:00", template: ExtData/CMIP6/sfc/SU/SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__energy_elevated.x720_y360_t12.%y4.nc }
+  GMI.CMIP6_SSP245_SO2_ENERGY.emis.monthly.2014-2100:  { valid_range: "2014-01-15T00:00/2100-12-17T12:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/sfc/SU/CMIP6ssp245.emis_SO2.energy.x720_y360_t12.%y4.nc4 }
+
+  # note: 2014 file for SSP245 is actually a pointer to CEDS
+  GMI.CMIP_CEDS_SO2_NONENERGY.emis.monthly.1950-2014:  { valid_range: "1950-01-15T00:00/2014-12-16T12:00", template: ExtData/CMIP6/sfc/SU/SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__nonenergy_surface.x720_y360_t12.%y4.nc }
+  GMI.CMIP6_SSP245_SO2_NONENERGY.emis.monthly.2014-2100: { valid_range: "2014-01-15T00:00/2100-12-17T12:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/sfc/SU/CMIP6ssp245.emis_SO2.sfcanthro.x720_y360_t12.%y4.nc4 }
+
+  # note: 2014 file for SSP245 is actually a pointer to CEDS
+  GMI.CMIP_CEDS_SO2_SHIPPING.emis.monthly.1950-2014:   { valid_range: "1950-01-15T00:00/2014-12-16T12:00", template: ExtData/CMIP6/sfc/SU/SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__shipping_surface.x720_y360_t12.%y4.nc }
+  GMI.CMIP6_SSP245_SO2_SHIPPING.emis.monthly.2014-2100: { valid_range: "2014-01-15T00:00/2100-12-17T12:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/sfc/SU/CMIP6ssp245.emis_SO2.ships.x720_y360_t12.%y4.nc4 }
+
+  # three datasets that each cover decades
+  GMI.CMIP_SO2_BB.monthly.1750-2015:                   { valid_range: "1750-01-15T00:00/2015-12-16T12:00", template: ExtData/CMIP6/sfc/SU/SO2-em-biomassburning_input4MIPs_emissions_CMIP_VUA-CMIP-BB4CMIP6-1-2_gn__surface.x1440_y720_t12.%y4.nc }
+  GMI.GFEDv4_SO2_BB.monthly.1977-2019:                 { valid_range: "1997-01-15T12:00/2019-12-15T12:00", template: /discover/nobackup/sstrode/emissions/CCMI/RefD1emis/gfedv4_1s.emis_so2.x1152_y721_t240.19970115_12z_20191215_12z.nc }
+  GMI.CMIP6_SSP245_SO2_BB.emis.monthly.2015-2100:      { valid_range: "2015-01-16T00:00/2100-12-17T12:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/sfc/SU/CMIP6ssp245.emis_SO2.biomassburning.x720_y360_t12.%y4.nc4 }
+
+  GMI.ODS.emis.monthly.1951-2100:                      { valid_range: "1951-01-15T12:00/2100-12-17T00:00", template: /discover/nobackup/ssteenro/qing/SC.ODS.Emission.x360_y181.%y4.V1.nc }
+
+  ## Climatologies
+
+  GMI.MEGAN_AEF_LAI.annual_clim:                       {                                                   template: ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc }  # just 1 time
+
+# GMI.DMS.monthly_clim:                                { valid_range: "1985-01-01T00:00/1985-12-01T00:00", template: /discover/nobackup/cakelle2/data/OCEAN/DMS_lana.geos.1x1.esmf.nc }
+  GMI.DMS.monthly_clim:                                { valid_range: "2011-01-14T12:00/2011-12-15T02:00", template: ExtData/chemistry/Lana/v2011/DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4 }
+  GMI.OCS.monthly_clim:                                { valid_range: "2016-01-15T12:00/2016-12-16T00:00", template: ExtData/g5chem/L72/OCS_vmr.x360_y181_z72.t12.2016.nc4 }
+  GMI.ACET.monthly_clim:                               { valid_range: "2001-01-15T12:00/2001-12-17T00:00", template: ExtData/g5chem/L72/acetone_fixed_GMI.x288_y181_z72_t12.2001.nc }
+  GMI.FERTILIZER.monthly_clim:                         { valid_range: "2006-01-15T12:00/2006-12-17T00:00", template: ExtData/g5chem/sfc/fertilizer_GMI.x288_y181_t12.2006.nc }
+  GMI.LAI.monthly_clim:                                { valid_range: "2008-01-15T12:00/2008-12-16T00:00", template: ExtData/g5chem/sfc/LAI/lai_x720_y360_v72_t12_2008.nc }
+  GMI.VEG_FRAC.monthly_clim:                           { valid_range: "2008-01-15T12:00/2008-12-16T00:00", template: ExtData/g5chem/sfc/LAI/veg_fraction_x720_y360_t12_2008.nc }
+  GMI.PRECIP.monthly_clim:                             { valid_range: "2006-01-15T12:00/2006-12-17T00:00", template: ExtData/g5chem/sfc/precipitation_GMI.x288_y181_t12.2006.nc }
+  GMI.aero_MERRA2.monthly_clim:                        { valid_range: "2017-01-15T12:00/2017-12-15T12:00", template: ExtData/chemistry/GMI/aerosols/GEOSCCM_aerodust_MERRA2_tavg3D_monavg_2017_2022.nc4 }
 
 Samplings:
-  GMI_sample_0:
-    extrapolation: clim
-    update_frequency: PT24H
-    update_offset: PT12H
-    update_reference_time: '0'
-  GMI_sample_1:
-    update_frequency: PT24H
-    update_offset: PT12H
-    update_reference_time: '0'
-  GMI_sample_2:
-    extrapolation: clim
-    update_frequency: P1M
-    update_reference_time: '0'
-  GMI_sample_3:
-    extrapolation: clim
+  GMI.daily:             { time_interpolation: true , update_frequency: PT24H,  update_offset: PT12H,  update_reference_time: '0', extrapolation: none            } # Update every 0Z, interpolate the value for noon
+  GMI.daily_wrap:        { time_interpolation: true , update_frequency: PT24H,  update_offset: PT12H,  update_reference_time: '0', extrapolation: clim            } # Update every 0Z, interpolate the value for noon; wrap first or last year
+  GMI.tdt_wrap:          { time_interpolation: true ,                                                                              extrapolation: clim            } # Update every timestep; wrap first or last year
+  GMI.constant:          { time_interpolation: false,                                                                              extrapolation: persist_closest }
+  GMI.monthly_wrap:      { time_interpolation: false, update_frequency: P1M,                                                       extrapolation: clim            } # Update every month on day 1; wrap as clim
 
 Exports:
-  BCphobic:
-    collection: GMI_aerodust_file
-    sample: GMI_sample_2
-    variable: BCPHOBIC
-  BCphilic:
-    collection: GMI_aerodust_file
-    sample: GMI_sample_2
-    variable: BCPHILIC
-  OCphobic:
-    collection: GMI_aerodust_file
-    sample: GMI_sample_2
-    variable: OCPHOBIC
-  OCphilic:
-    collection: GMI_aerodust_file
-    sample: GMI_sample_2
-    variable: OCPHILIC
-  SO4:
-    collection: GMI_aerodust_file
-    sample: GMI_sample_2
-    variable: SO4
-  SO4v:
-    collection: /dev/null
-  ss001:
-    collection: GMI_aerodust_file
-    sample: GMI_sample_2
-    variable: SS001
-  ss002:
-    collection: GMI_aerodust_file
-    sample: GMI_sample_2
-    variable: SS002
-  ss003:
-    collection: GMI_aerodust_file
-    sample: GMI_sample_2
-    variable: SS003
-  ss004:
-    collection: GMI_aerodust_file
-    sample: GMI_sample_2
-    variable: SS004
-  ss005:
-    collection: GMI_aerodust_file
-    sample: GMI_sample_2
-    variable: SS005
-  du001:
-    collection: GMI_aerodust_file
-    sample: GMI_sample_2
-    variable: DU001
-  du002:
-    collection: GMI_aerodust_file
-    sample: GMI_sample_2
-    variable: DU002
-  du003:
-    collection: GMI_aerodust_file
-    sample: GMI_sample_2
-    variable: DU003
-  du004:
-    collection: GMI_aerodust_file
-    sample: GMI_sample_2
-    variable: DU004
-  du005:
-    collection: GMI_aerodust_file
-    sample: GMI_sample_2
-    variable: DU005
-  ACET_FIXED:
-    collection: GMI_acetone_fixed_GMI.x288_y181_z72_t12.2001.nc
-    sample: GMI_sample_0
-    variable: ACET
+  ACET_FIXED:                  { variable: ACET,                 collection: GMI.ACET.monthly_clim,                                                   sample: GMI.daily_wrap        }
+
   ALD2_biof:
-    collection: /dev/null
+    - { starting: "2000-01-01",  variable: ALD2_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-01-01",  variable: ALD2_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
   ALD2_biom:
-    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: ALD2_bb
-  ALK4_biof:
-    collection: /dev/null
+    - { starting: "1950-01-01",  variable: ALD2_bb,              collection: GMI.CMIP6_BB.emis.monthly.1950-2015,                  regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-12-01",  variable: ALD2_bb,              collection: GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
+  ALK4_biof:                   {                                 collection: /dev/null                                                                                              }
+
   ALK4_biom:
-    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: ALK4_bb
+    - { starting: "1950-01-01",  variable: ALK4_bb,              collection: GMI.CMIP6_BB.emis.monthly.1950-2015,                  regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-12-01",  variable: ALK4_bb,              collection: GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
   ALK4_fosf:
-    collection: GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: ALK4_ff
-  C2H6_biof:
-    collection: /dev/null
+    - { starting: "2000-01-01",  variable: ALK4_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-01-01",  variable: ALK4_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
+  C2H6_biof:                   {                                 collection: /dev/null                                                                                              }
+
   C2H6_biom:
-    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: C2H6_bb
+    - { starting: "1950-01-01",  variable: C2H6_bb,              collection: GMI.CMIP6_BB.emis.monthly.1950-2015,                  regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-12-01",  variable: C2H6_bb,              collection: GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
   C2H6_fosf:
-    collection: GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: C2H6_ff
-  C3H8_biof:
-    collection: /dev/null
+    - { starting: "2000-01-01",  variable: C2H6_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-01-01",  variable: C2H6_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
+  C3H8_biof:                   {                                 collection: /dev/null                                                                                              }
+
   C3H8_biom:
-    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: C3H8_bb
+    - { starting: "1950-01-01",  variable: C3H8_bb,              collection: GMI.CMIP6_BB.emis.monthly.1950-2015,                  regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-12-01",  variable: C3H8_bb,              collection: GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
   C3H8_fosf:
-    collection: GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: C3H8_ff
-  CCL4_FLUX:
-    collection: GMI_SC.ODS.Emission.x360_y181.%y4.V1.nc
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: CCL4_emission
-  CFC113_FLUX:
-    collection: GMI_SC.ODS.Emission.x360_y181.%y4.V1.nc
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: CFC113_emission
-  CFC11_FLUX:
-    collection: GMI_SC.ODS.Emission.x360_y181.%y4.V1.nc
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: CFC11_emission
-  CFC12_FLUX:
-    collection: GMI_SC.ODS.Emission.x360_y181.%y4.V1.nc
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: CFC12_emission
-  CH2BR2_FLUX:
-    collection: GMI_SC.ODS.Emission.x360_y181.%y4.V1.nc
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: CH2BR2_emission
+    - { starting: "2000-01-01",  variable: C3H8_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-01-01",  variable: C3H8_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
   CH2O_biof:
-    collection: /dev/null
+    - { starting: "2000-01-01",  variable: CH2O_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-01-01",  variable: CH2O_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
   CH2O_biom:
-    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: CH2O_bb
-  CH3CCL3_FLUX:
-    collection: GMI_SC.ODS.Emission.x360_y181.%y4.V1.nc
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: CH3CCL3_emission
-  CH4_aggr:
-    collection: /dev/null
-  CH4_biom:
-    collection: /dev/null
-  CHBR3_FLUX:
-    collection: GMI_SC.ODS.Emission.x360_y181.%y4.V1.nc
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: CHBR3_emission
-  CO_biof:
-    collection: /dev/null
+    - { starting: "1950-01-01",  variable: CH2O_bb,              collection: GMI.CMIP6_BB.emis.monthly.1950-2015,                  regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-12-01",  variable: CH2O_bb,              collection: GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
+  CH4_aggr:                    {                                 collection: /dev/null                                                                                              }
+
+  CH4_biom:                    {                                 collection: /dev/null                                                                                              }
+
+  CO_biof:                     {                                 collection: /dev/null                                                                                              }
+
   CO_biom:
-    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: CO_bb
+    - { starting: "1950-01-01",  variable: CO_bb,                collection: GMI.CMIP6_BB.emis.monthly.1950-2015,                  regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-12-01",  variable: CO_bb,                collection: GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
   CO_fosf:
-    collection: GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: CO_ff
-  DMS_OCEAN:
-    collection: GMI_DMS_lana.geos.1x1.esmf.nc
-    regrid: CONSERVE
-    sample: GMI_sample_2
-    variable: DMS_OCEAN
-  HCFC22_FLUX:
-    collection: GMI_SC.ODS.Emission.x360_y181.%y4.V1.nc
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: HCFC22_emission
-  LAI_FRAC:
-    collection: GMI_lai_x720_y360_v72_t12_2008.nc
-    sample: GMI_sample_0
-    variable: LAI_FRAC
-  MEGAN_ISOP:
-    collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-    regrid: CONSERVE
-    sample: GMI_sample_3
-    variable: BIOGSRCE_AEF_ISOP
-  MEGAN_LAI_001:
-    collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-    sample: GMI_sample_3
-    variable: AVHRR_LAI_001
-  MEGAN_LAI_002:
-    collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-    sample: GMI_sample_3
-    variable: AVHRR_LAI_002
-  MEGAN_LAI_003:
-    collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-    sample: GMI_sample_3
-    variable: AVHRR_LAI_003
-  MEGAN_LAI_004:
-    collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-    sample: GMI_sample_3
-    variable: AVHRR_LAI_004
-  MEGAN_LAI_005:
-    collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-    sample: GMI_sample_3
-    variable: AVHRR_LAI_005
-  MEGAN_LAI_006:
-    collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-    sample: GMI_sample_3
-    variable: AVHRR_LAI_006
-  MEGAN_LAI_007:
-    collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-    sample: GMI_sample_3
-    variable: AVHRR_LAI_007
-  MEGAN_LAI_008:
-    collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-    sample: GMI_sample_3
-    variable: AVHRR_LAI_008
-  MEGAN_LAI_009:
-    collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-    sample: GMI_sample_3
-    variable: AVHRR_LAI_009
-  MEGAN_LAI_010:
-    collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-    sample: GMI_sample_3
-    variable: AVHRR_LAI_010
-  MEGAN_LAI_011:
-    collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-    sample: GMI_sample_3
-    variable: AVHRR_LAI_011
-  MEGAN_LAI_012:
-    collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-    sample: GMI_sample_3
-    variable: AVHRR_LAI_012
-  MEGAN_MBO:
-    collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-    regrid: CONSERVE
-    sample: GMI_sample_3
-    variable: BIOGSRCE_AEF_MBO
-  MEGAN_MPE:
-    collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-    regrid: CONSERVE
-    sample: GMI_sample_3
-    variable: BIOGSRCE_AEF_MPE
-  MEGAN_OVOC:
-    collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-    regrid: CONSERVE
-    sample: GMI_sample_3
-    variable: BIOGSRCE_AEF_OVC
-  MEK_biof:
-    collection: /dev/null
+    - { starting: "2000-01-01",  variable: CO_ff,                collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-01-01",  variable: CO_ff,                collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
+  MEK_biof:                    {                                 collection: /dev/null                                                                                              }
+
   MEK_biom:
-    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: MEK_bb
+    - { starting: "1950-01-01",  variable: MEK_bb,               collection: GMI.CMIP6_BB.emis.monthly.1950-2015,                  regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-12-01",  variable: MEK_bb,               collection: GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
   MEK_fosf:
-    collection: GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: MEK_ff
-  N2O_ANTHRO-FLUX:
-    collection: GMI_SC.ODS.Emission.x360_y181.%y4.V1.nc
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: N2OANTHRO_emission
-  N2O_LAND-FLUX:
-    collection: GMI_SC.ODS.Emission.x360_y181.%y4.V1.nc
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: N2OLAND_emission
-  N2O_OCEAN-FLUX:
-    collection: GMI_SC.ODS.Emission.x360_y181.%y4.V1.nc
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: N2OOCEAN_emission
+    - { starting: "2000-01-01",  variable: MEK_ff,               collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-01-01",  variable: MEK_ff,               collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
   NO_air:
-    collection: GMI_CMIP6_CEDS.airNOemis.x720_y360_z72_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: NO_air
-  NO_biof:
-    collection: /dev/null
+    - { starting: "1950-01-01",  variable: NO_air,               collection: GMI.CMIP6_CEDS_AirNO.emis.monthly.1950-2014,          regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2014-12-01",  variable: NO_air,               collection: GMI.CMIP6_SSP245_AirNO.emis.monthly.2014-2100,        regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
+  NO_biof:                     {                                 collection: /dev/null                                                                                              }
+
   NO_biom:
-    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: NO_bb
+    - { starting: "1950-01-01",  variable: NO_bb,                collection: GMI.CMIP6_BB.emis.monthly.1950-2015,                  regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-12-01",  variable: NO_bb,                collection: GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
   NO_fosf:
-    collection: GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: NO_ff
-  NO_lgt:
-    collection: /dev/null
-  NO_pwrp:
-    collection: /dev/null
-  NO_ship:
-    collection: /dev/null
-  OCS_CLIMO:
-    collection: GMI_OCS_vmr.x360_y181_z72.t12.2016.nc4
-    sample: GMI_sample_0
-    variable: ocs
-  PRPE_biof:
-    collection: /dev/null
+    - { starting: "2000-01-01",  variable: NO_ff,                collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-01-01",  variable: NO_ff,                collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
+
+  NO_pwrp:                     {                                 collection: /dev/null                                                                                              }
+  NO_lgt:                      {                                 collection: /dev/null                                                                                              }
+  NO_ship:                     {                                 collection: /dev/null                                                                                              }
+  PRPE_biof:                   {                                 collection: /dev/null                                                                                              }
+
   PRPE_biom:
-    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: PRPE_bb
+    - { starting: "1950-01-01",  variable: PRPE_bb,              collection: GMI.CMIP6_BB.emis.monthly.1950-2015,                  regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-12-01",  variable: PRPE_bb,              collection: GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
   PRPE_fosf:
-    collection: GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: PRPE_ff
-  SAD:
-    collection: GMI_sad_wt_CMIP6_288x181x72_%y4.nc
-    sample: GMI_sample_1
-    variable: lbssad
-  SHIP_NO:
-    collection: GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: NO_shp
+    - { starting: "2000-01-01",  variable: PRPE_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-01-01",  variable: PRPE_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
+  CCL4_FLUX:                   { variable:      CCL4_emission,   collection: GMI.ODS.emis.monthly.1951-2100,                       regrid: CONSERVE,  sample: GMI.daily             }
+  CFC113_FLUX:                 { variable:    CFC113_emission,   collection: GMI.ODS.emis.monthly.1951-2100,                       regrid: CONSERVE,  sample: GMI.daily             }
+  CFC11_FLUX:                  { variable:     CFC11_emission,   collection: GMI.ODS.emis.monthly.1951-2100,                       regrid: CONSERVE,  sample: GMI.daily             }
+  CFC12_FLUX:                  { variable:     CFC12_emission,   collection: GMI.ODS.emis.monthly.1951-2100,                       regrid: CONSERVE,  sample: GMI.daily             }
+  CH2BR2_FLUX:                 { variable:    CH2BR2_emission,   collection: GMI.ODS.emis.monthly.1951-2100,                       regrid: CONSERVE,  sample: GMI.daily             }
+  CH3CCL3_FLUX:                { variable:   CH3CCL3_emission,   collection: GMI.ODS.emis.monthly.1951-2100,                       regrid: CONSERVE,  sample: GMI.daily             }
+  CHBR3_FLUX:                  { variable:     CHBR3_emission,   collection: GMI.ODS.emis.monthly.1951-2100,                       regrid: CONSERVE,  sample: GMI.daily             }
+  HCFC22_FLUX:                 { variable:    HCFC22_emission,   collection: GMI.ODS.emis.monthly.1951-2100,                       regrid: CONSERVE,  sample: GMI.daily             }
+  N2O_ANTHRO-FLUX:             { variable: N2OANTHRO_emission,   collection: GMI.ODS.emis.monthly.1951-2100,                       regrid: CONSERVE,  sample: GMI.daily             }
+  N2O_LAND-FLUX:               { variable:   N2OLAND_emission,   collection: GMI.ODS.emis.monthly.1951-2100,                       regrid: CONSERVE,  sample: GMI.daily             }
+  N2O_OCEAN-FLUX:              { variable:  N2OOCEAN_emission,   collection: GMI.ODS.emis.monthly.1951-2100,                       regrid: CONSERVE,  sample: GMI.daily             }
+
   SO2_AIRCRAFT-FLUX:
-    collection: GMI_CMIP6_CEDS.airSO2emis.x720_y360_z72_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: SO2_aviation
+    - { starting: "1950-01-01",  variable: SO2_aviation,         collection: GMI.CMIP6_CEDS_AirSO2.emis.monthly.1950-2014,         regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2014-12-01",  variable: SO2_aviation,         collection: GMI.CMIP6_SSP245_AirSO2.emis.monthly.2014-2100,       regrid: CONSERVE,  sample: GMI.daily_wrap        }  # 2020
+
   SO2_ENERGY-FLUX:
-    collection: GMI_SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__energy_elevated.x720_y360_t12.%y4.nc
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: SO2_energy
-  SO2_FIRES-FLUX:
-    collection: GMI_SO2-em-biomassburning_input4MIPs_emissions_CMIP_VUA-CMIP-BB4CMIP6-1-2_gn__surface.x1440_y720_t12.%y4.nc
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: SO2
+    - { starting: "1950-01-01",  variable: SO2_energy,           collection: GMI.CMIP_CEDS_SO2_ENERGY.emis.monthly.1950-2014,      regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2014-12-01",  variable: SO2_energy,           collection: GMI.CMIP6_SSP245_SO2_ENERGY.emis.monthly.2014-2100,   regrid: CONSERVE,  sample: GMI.daily_wrap        }  # 2020
+
+  SO2_FIRES-FLUX:              { variable: SO2,                  collection: GMI.CMIP_SO2_BB.monthly.1750-2015,                    regrid: CONSERVE,  sample: GMI.daily_wrap        }  # last full year is 2015
+
   SO2_NONENERGY-FLUX:
-    collection: GMI_SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__nonenergy_surface.x720_y360_t12.%y4.nc
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: SO2_nonenergy
+    - { starting: "1950-01-01",  variable: SO2_nonenergy,        collection: GMI.CMIP_CEDS_SO2_NONENERGY.emis.monthly.1950-2014,   regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2014-12-01",  variable: SO2_nonenergy,        collection: GMI.CMIP6_SSP245_SO2_NONENERGY.emis.monthly.2014-2100, regrid: CONSERVE,  sample: GMI.daily_wrap        }  # 2020
+
   SO2_SHIPPING-FLUX:
-    collection: GMI_SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__shipping_surface.x720_y360_t12.%y4.nc
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: SO2_shipping
-  SOILFERT:
-    collection: GMI_fertilizer_GMI.x288_y181_t12.2006.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: soilFert
-  SOILPRECIP:
-    collection: GMI_precipitation_GMI.x288_y181_t12.2006.nc
-    sample: GMI_sample_0
-    variable: soilPrecip
-  VEG_FRAC:
-    collection: GMI_veg_fraction_x720_y360_t12_2008.nc
-    sample: GMI_sample_0
-    variable: VEG_FRAC
+    - { starting: "1950-01-01",  variable: SO2_shipping,         collection: GMI.CMIP_CEDS_SO2_SHIPPING.emis.monthly.1950-2014,    regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2014-12-01",  variable: SO2_shipping,         collection: GMI.CMIP6_SSP245_SO2_SHIPPING.emis.monthly.2014-2100, regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
+# DMS_OCEAN:                   { variable: DMS_OCEAN,            collection: GMI.DMS.monthly_clim,                                 regrid: CONSERVE,  sample: GMI.monthly_wrap      }
+  DMS_OCEAN:                   { variable: conc,                 collection: GMI.DMS.monthly_clim,                                 regrid: CONSERVE,  sample: GMI.daily_wrap,       linear_transformation: [ 0.0, 62.13e-9 ] }
+
+  OCS_CLIMO:                   { variable: ocs,                  collection: GMI.OCS.monthly_clim,                                                    sample: GMI.daily_wrap        }
+
+
+  SAD:
+    - { starting: "1850-01-01",  variable: lbssad,               collection: GMI.CMIP6_SAD.monthly.1850-2018,                                         sample: GMI.daily_wrap        }
+    - { starting: "2015-02-01",  variable: lbssad,               collection: GMI.CMIP6_SAD_shift_to_climo.monthly.2015-2023,                          sample: GMI.daily             }
+    - { starting: "2023-12-01",  variable: lbssad,               collection: GMI.CMIP6_SAD.monthly_clim,                                              sample: GMI.daily_wrap        }
+
+  SHIP_NO:
+    - { starting: "2000-01-01",  variable: NO_shp,               collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-01-01",  variable: NO_shp,               collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
+  SOILFERT:                    { variable: soilFert,             collection: GMI.FERTILIZER.monthly_clim,                          regrid: CONSERVE,  sample: GMI.daily_wrap        }
+  SOILPRECIP:                  { variable: soilPrecip,           collection: GMI.PRECIP.monthly_clim,                                                 sample: GMI.daily_wrap        }
+  LAI_FRAC:                    { variable: LAI_FRAC,             collection: GMI.LAI.monthly_clim,                                                    sample: GMI.daily_wrap        }
+  VEG_FRAC:                    { variable: VEG_FRAC,             collection: GMI.VEG_FRAC.monthly_clim,                                               sample: GMI.daily_wrap        }
+
+  MEGAN_ISOP:                  { variable: BIOGSRCE_AEF_ISOP,    collection: GMI.MEGAN_AEF_LAI.annual_clim,                        regrid: CONSERVE,  sample: GMI.constant          }
+  MEGAN_MBO:                   { variable: BIOGSRCE_AEF_MBO,     collection: GMI.MEGAN_AEF_LAI.annual_clim,                        regrid: CONSERVE,  sample: GMI.constant          }
+  MEGAN_MPE:                   { variable: BIOGSRCE_AEF_MPE,     collection: GMI.MEGAN_AEF_LAI.annual_clim,                        regrid: CONSERVE,  sample: GMI.constant          }
+  MEGAN_OVOC:                  { variable: BIOGSRCE_AEF_OVC,     collection: GMI.MEGAN_AEF_LAI.annual_clim,                        regrid: CONSERVE,  sample: GMI.constant          }
+  MEGAN_LAI_001:               { variable: AVHRR_LAI_001,        collection: GMI.MEGAN_AEF_LAI.annual_clim,                                           sample: GMI.constant          }
+  MEGAN_LAI_002:               { variable: AVHRR_LAI_002,        collection: GMI.MEGAN_AEF_LAI.annual_clim,                                           sample: GMI.constant          }
+  MEGAN_LAI_003:               { variable: AVHRR_LAI_003,        collection: GMI.MEGAN_AEF_LAI.annual_clim,                                           sample: GMI.constant          }
+  MEGAN_LAI_004:               { variable: AVHRR_LAI_004,        collection: GMI.MEGAN_AEF_LAI.annual_clim,                                           sample: GMI.constant          }
+  MEGAN_LAI_005:               { variable: AVHRR_LAI_005,        collection: GMI.MEGAN_AEF_LAI.annual_clim,                                           sample: GMI.constant          }
+  MEGAN_LAI_006:               { variable: AVHRR_LAI_006,        collection: GMI.MEGAN_AEF_LAI.annual_clim,                                           sample: GMI.constant          }
+  MEGAN_LAI_007:               { variable: AVHRR_LAI_007,        collection: GMI.MEGAN_AEF_LAI.annual_clim,                                           sample: GMI.constant          }
+  MEGAN_LAI_008:               { variable: AVHRR_LAI_008,        collection: GMI.MEGAN_AEF_LAI.annual_clim,                                           sample: GMI.constant          }
+  MEGAN_LAI_009:               { variable: AVHRR_LAI_009,        collection: GMI.MEGAN_AEF_LAI.annual_clim,                                           sample: GMI.constant          }
+  MEGAN_LAI_010:               { variable: AVHRR_LAI_010,        collection: GMI.MEGAN_AEF_LAI.annual_clim,                                           sample: GMI.constant          }
+  MEGAN_LAI_011:               { variable: AVHRR_LAI_011,        collection: GMI.MEGAN_AEF_LAI.annual_clim,                                           sample: GMI.constant          }
+  MEGAN_LAI_012:               { variable: AVHRR_LAI_012,        collection: GMI.MEGAN_AEF_LAI.annual_clim,                                           sample: GMI.constant          }
+
+  BCphobic:                    { variable: BCPHOBIC,             collection: GMI.aero_MERRA2.monthly_clim,                         regrid: CONSERVE,  sample: GMI.daily_wrap        }
+  BCphilic:                    { variable: BCPHILIC,             collection: GMI.aero_MERRA2.monthly_clim,                         regrid: CONSERVE,  sample: GMI.daily_wrap        }
+  OCphobic:                    { variable: OCPHOBIC,             collection: GMI.aero_MERRA2.monthly_clim,                         regrid: CONSERVE,  sample: GMI.daily_wrap        }
+  OCphilic:                    { variable: OCPHILIC,             collection: GMI.aero_MERRA2.monthly_clim,                         regrid: CONSERVE,  sample: GMI.daily_wrap        }
+  ss001:                       { variable: SS001,                collection: GMI.aero_MERRA2.monthly_clim,                         regrid: CONSERVE,  sample: GMI.daily_wrap        }
+  ss002:                       { variable: SS002,                collection: GMI.aero_MERRA2.monthly_clim,                         regrid: CONSERVE,  sample: GMI.daily_wrap        }
+  ss003:                       { variable: SS003,                collection: GMI.aero_MERRA2.monthly_clim,                         regrid: CONSERVE,  sample: GMI.daily_wrap        }
+  ss004:                       { variable: SS004,                collection: GMI.aero_MERRA2.monthly_clim,                         regrid: CONSERVE,  sample: GMI.daily_wrap        }
+  ss005:                       { variable: SS005,                collection: GMI.aero_MERRA2.monthly_clim,                         regrid: CONSERVE,  sample: GMI.daily_wrap        }
+  SO4:                         { variable: SO4,                  collection: GMI.aero_MERRA2.monthly_clim,                         regrid: CONSERVE,  sample: GMI.daily_wrap        }
+  SO4v:                        {                                 collection: /dev/null                                                                                              }
+  du001:                       { variable: DU001,                collection: GMI.aero_MERRA2.monthly_clim,                         regrid: CONSERVE,  sample: GMI.daily_wrap        }
+  du002:                       { variable: DU002,                collection: GMI.aero_MERRA2.monthly_clim,                         regrid: CONSERVE,  sample: GMI.daily_wrap        }
+  du003:                       { variable: DU003,                collection: GMI.aero_MERRA2.monthly_clim,                         regrid: CONSERVE,  sample: GMI.daily_wrap        }
+  du004:                       { variable: DU004,                collection: GMI.aero_MERRA2.monthly_clim,                         regrid: CONSERVE,  sample: GMI.daily_wrap        }
+  du005:                       { variable: DU005,                collection: GMI.aero_MERRA2.monthly_clim,                         regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
+  CH4_BC:                      { variable: CH4,       collection: GMI.CH4_surf_values.clim,                              regrid: CONSERVE,  sample: GMI.constant             }

--- a/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_GridComp.rc
+++ b/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_GridComp.rc
@@ -215,7 +215,7 @@ SO2:volcano:ExtData/chemistry/CARN/v202106/sfc/so2_volcanic_emissions_Carns.%y4%
 # Ship Emissions requires SHIP_NO in ExtData:
 do_ShipEmission: T
 doMEGANemission: T
-doMEGANviaHEMCO: T
+doMEGANviaHEMCO: F
 
 isop_scale::
 0.7d0

--- a/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_GridComp.rc
+++ b/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_GridComp.rc
@@ -140,13 +140,22 @@ MEK_biom
 CO_biom
 NO_biom
 NO_air
+ALD2_biof
 ALK4_fosf
+ALK4_biof
 C2H6_fosf
+C2H6_biof
 PRPE_fosf
+PRPE_biof
 C3H8_fosf
+C3H8_biof
+CH2O_biof
 MEK_fosf
+MEK_biof
 CO_fosf
+CO_biof
 NO_fosf
+NO_biof
 SO2_FIRES-FLUX
 SO2_NONENERGY-FLUX
 SO2_ENERGY-FLUX
@@ -176,32 +185,51 @@ emissionSpeciesLayers::
 1
 1
 1
+1
+1
+1
+1
+1
+1
+1
+1
+1
 72
 ::
 
 emissionPointFilenames::
-SO2:volcano:/discover/nobackup/projects/gmao/share/dao_ops/fvInput_nc3/PIESA/sfc/volcanic_v7/so2_volcanic_emissions_Carns.%y4%m2%d2.rc
+SO2:volcano:ExtData/chemistry/CARN/v202106/sfc/so2_volcanic_emissions_Carns.%y4%m2%d2.rc
 ::
-#SO2:volcano:/discover/nobackup/projects/gmao/share/dao_ops/fvInput_nc3/PIESA/sfc/volcanic_v7/so2_volcanic_effusive.v2.rc 
+# NOTE: Units for the volcano point source files: kg(S)/s
+#       Units that GMI wants                    : kg(SO2)/s
+#       GMI does the conversion in Refresh_Daily within the Emission section
+# from GOCART2G SU (AMIP):
+#   ExtData/chemistry/CARN/v202106/sfc/so2_volcanic_emissions_Carns.%y4%m2%d2.rc
+# from GOCART2G SU (OPS):
+#   ExtData/chemistry/CARN/v202106/sfc/so2_volcanic_emissions_CARN_v202106.degassing_only.rc
+# includes eruptions:
+#   /discover/nobackup/projects/gmao/share/dao_ops/fvInput_nc3/PIESA/sfc/volcanic_v7/so2_volcanic_emissions_Carns.%y4%m2%d2.rc
+# does not include eruptions:
+#   /discover/nobackup/projects/gmao/share/dao_ops/fvInput_nc3/PIESA/sfc/volcanic_v7/so2_volcanic_effusive.v2.rc 
 
 # Ship Emissions requires SHIP_NO in ExtData:
 do_ShipEmission: T
 doMEGANemission: T
-doMEGANviaHEMCO: F
+doMEGANviaHEMCO: T
 
 isop_scale::
-1.0d0
-1.0d0
-1.0d0
-1.0d0
-1.0d0
-1.0d0
-1.0d0
-1.0d0
-1.0d0
-1.0d0
-1.0d0
-1.0d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
 ::
 
 soil_infile_name:      ExtData/g5chem/x/GMI_SoilType.asc
@@ -262,7 +290,11 @@ forc_bc_kmax: 2
 #forc_bc_infile_name: /discover/nobackup/ldoman/fvInput/RCP6.0_5BrWMO2014_ch4latvar_1950_2100.asc
 #forc_bc_infile_name:              ExtData/g5chem/x/GMI/RCP6.0_5BrWMO2014_ch4latvar_1950_2100.asc
 #forc_bc_infile_name:              ExtData/g5chem/x/GMI/RCP6.0_5BrWMO2018_ch4latvar_1950_2100.asc
-forc_bc_infile_name:               ExtData/g5chem/x/GMI/ccmiRefD1_GMIbc_1950_2018.asc
+#forc_bc_infile_name:              ExtData/g5chem/x/GMI/ccmiRefD1_GMIbc_1950_2018.asc
+#forc_bc_infile_name:  /discover/nobackup/projects/gmao/ccmdev/mmanyin/bench/bench_10-26-0_gmi_free_c360_72lev/INPUT/BC/ccmiRefD1_GMIbc_plusHFC_1950_2018.asc
+forc_bc_infile_name:  /discover/nobackup/projects/gmao/ccmdev/mmanyin/bench/GOLF/INPUT/BC/ccmiRefD1_GMIbc_plusHFC_no5Br_1950_2018.asc
+
+#alternative /discover/nobackup/projects/gmi/gmidata2/users/steenrod/input/source_gas/RCP6.0_WMO2018_QingHFCs_ch4latvarGMDscl_1950_2022Hindcast.asc
 
 forcedBcSpeciesNames:: 
 CFC11
@@ -283,7 +315,18 @@ CH3Br
 CH3Cl
 CH4
 N2O
+HFC23
+HFC32
+HFC125
+HFC134A
+HFC143A
+HFC152A
+xxx
+xxx
 ::
+
+# The xxx entries above are for SF6 and CO2
+
 
 #     ----------------------------------------------------
 #     sad_opt
@@ -371,8 +414,8 @@ do_ozone_inFastJX: F
 
 ## For FastJX 6.5 & JPL10
  fastj_opt: 4
-# cross_section_file: ExtData/g5chem/x/photolysis/FastJX_6.5/xsec_jx65_jpl10update2_JNOx1_0.dat
  cross_section_file: ExtData/g5chem/x/photolysis/FastJX_6.5/xsec_jx65wSO4_jpl10update2_JNOx1_0.dat
+# cross_section_file: ExtData/g5chem/x/photolysis/FastJX_6.5/xsec_jx65_jpl10update2_JNOx1_0.dat
 # rate_file not needed for FastJX6.5; new approach only differs by roundoff
 # rate_file: ExtData/g5chem/x/photolysis/FastJX/ratec_124spc_jx_gmiv2.dat
 # rate_file: ExtData/g5chem/x/photolysis/FastJX/ratec_119spc_jx_gmiv3.dat
@@ -414,7 +457,7 @@ FeedBack_QV: T
 NoPSCZone: 45
 PSC_Max_P_hPa: 175
 # Upper limit for HNO3COND [integer, ppbv]
-Condensed_HNO3_limit: 25
+Condensed_HNO3_limit: 75
 # Upper limit for HCl [real, ppbv]
 HCl_limit: 5.0
 

--- a/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/setkin_kcalc.F90
+++ b/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/setkin_kcalc.F90
@@ -2157,40 +2157,56 @@
 !
 !_1_
 !
-!.... JPL 97-4
+!.... JPL 19-5
 !
-        FUNCTION sksts_n2o5 (tk,pr,sad,ptrop)
-          real*8, OPTIONAL :: ptrop
-          real*8  tk(:) ,pr(:) ,sad(:)
-          real*8, DIMENSION (size(tk)) :: sksts_n2o5
-          real*8  gamma ,pi
-          real*8  avgvel(size(tk))
+      FUNCTION sksts_n2o5 (tk,pr,sad,ptrop)
 !
-          pi = acos(-1.0d0)
+      real*8, OPTIONAL :: ptrop
+      real*8  tk(:) ,pr(:) ,sad(:)
+      real*8, DIMENSION (size(tk)) :: sksts_n2o5
+      real*8  pi
+      real*8  avgvel(size(tk))
+!.sds..      real*8  gamma
+!... update
+      real*8  gamma(size(tk)), wt, k0, k1, k2
+!
+      pi = acos(-1.0d0)
 !
 !=======================================================================
 !     N2O5 + stratospheric sulfate aerosol = 2 HNO3
 !=======================================================================
+!           
+!.sds..!.... First order reaction rate constant
+!.sds..!.... PSC 3/30/99
+!.sds..      gamma     = 0.10d0
 !
-!.... First order reaction rate constant
-!.... PSC 3/30/99
+!... update gamma calc (older than JPL15)
 !
-          gamma     = 0.10d0
+!... weight % of H2SO4
+!.STS..      wt = 60.0d0
+      wt = 75.0d0
 !
-          avgvel(:) = 100.0d0 * (8.0d0 * 8.31448d0 * tk(:) * 1000.0d0 /  &
-     &                (pi * mw(IN2O5)))**0.5d0
+!... JPL19
+      k0 = -25.5265 - 0.133188*wt + 0.00930846*wt*wt - 9.0194e-5*wt*wt*wt
+      k1 =  9283.76 +  115.345*wt -    5.19258*wt*wt + 0.0483464*wt*wt*wt
+      k2 = -851801. -  22191.2*wt +    766.916*wt*wt -   6.85427*wt*wt*wt
+      gamma(:) = exp (k0 + k1/tk(:) + k2/(tk(:)*tk(:)))
+!.end update
 !
-          where( sad > 0.0d0 )
-            sksts_n2o5   = 0.25d0 * gamma * avgvel * sad
-          elsewhere
-            sksts_n2o5   = 0.0d0
-          end where
+      avgvel(:) = 100.0d0 * (8.0d0 * 8.31448d0 * tk(:) * 1000.0d0 /  &
+                 (pi * mw(IN2O5)))**0.5d0
 !
-          if ( present(ptrop) ) then
-            where( pr > ptrop ) sksts_n2o5 = 0.0d0
-          end if
+      where ( sad > 0.0d0 )
+        sksts_n2o5   = 0.25d0 * gamma * avgvel * sad
+      elsewhere
+        sksts_n2o5   = 0.0d0
+      endwhere
 !
-        END FUNCTION sksts_n2o5
+      if ( present(ptrop) ) then
+        where ( pr > ptrop ) sksts_n2o5 = 0.0d0
+      endif
+!
+      END FUNCTION sksts_n2o5
 !
 !.... sksts_clono2 (temperature ,adcol ,pressure ,sad_lbs ,specarr( HCl,:) ,water ,ptrop)
 !
@@ -2301,7 +2317,7 @@
 !
 !_3_
 !
-!.... JPL 97-4
+!.... JPL 15-10
 !
         FUNCTION sksts_brono2 (tk,pr,sad,ptrop)
           real*8, OPTIONAL :: ptrop
@@ -2309,6 +2325,7 @@
           real*8, DIMENSION (size(tk)) :: sksts_brono2
           real*8  gamma ,pi
           real*8  avgvel(size(tk))
+          real*8  wt
 !
           pi = acos(-1.0d0)
 !
@@ -2320,10 +2337,24 @@
 !
 !.... David Hanson, personal communication, May 13, 1997
 !
-          avgvel = 100.0d0 * (8.0d0 * 8.31448d0 * tk(:) * 1000.0d0 /  &
-     &             (pi * mw(IBRONO2)))**0.5d0
+!.orig          gamma = 0.8d0
 !
-          gamma = 0.8d0
+!... JPL15-6 formulation
+!   Hanson has fit an empirical expression for measured gammas for BrONO2 + H2O in the form
+!    of:
+!      1/gamma = 1/alpha + 1/gamma(rxn)
+!    where
+!      gamma(rxn) = exp(a+b*wt)
+!      alpha = 0.80,
+!      a = 29.2,
+!      b = -0.40.
+!... assumed %wt for GMI
+      wt = 75.0d0
+!
+      gamma = 1.0d0 / ( 1.0d0/0.80d0 + 1.0d0/(exp(29.2d0-0.40d0*wt)) )
+!
+          avgvel = 100.0d0 * (8.0d0 * 8.31448d0 * tk(:) * 1000.0d0 /  &
+                  (pi * mw(IBRONO2)))**0.5d0
 !
           sksts_brono2 = 0.25d0 * gamma * avgvel * sad
 !
@@ -3003,7 +3034,7 @@
 !.... JPL 00-003
 !.... PSC 1/16/2002
 !
-          gprob            = 0.30d0
+          gprob            = 0.26d0   ! sds JPL19
           avgvel(:)        = 100.0d0 * (8.0d0 * 8.31448d0 * tk(:) * 1000.0d0 /  &
      &                       (pi * mw(IBRONO2)))**0.5d0
 !
@@ -3123,7 +3154,7 @@
 !.... PSC 1/16/2002
 !
           minconc              = 1.0d0
-          gprob                = 0.30d0
+          gprob                = 0.26d0   ! sds JPL19
           avgvel(:)            = 100.0d0 * (8.0d0 * 8.31448d0 * tk(:) *  &
      &                            1000.0d0 /  &
      &                           (pi * mw(IBRONO2)))**0.5d0
@@ -3166,7 +3197,7 @@
 !.... PSC 1/16/2002
 !
           minconc            = 1.0d0
-          gprob              = 0.20d0
+          gprob              = 0.30d0   ! sds JPL19
           avgvel(:)          = 100.0d0 * (8.0d0 * 8.31448d0 * tk(:) * 1000.0d0 /  &
      &                         (pi * mw(IHOBR)))**0.5d0
 !

--- a/GMI_GridComp/GmiChemistry/StratTrop_Orig/GMI_GridComp.rc
+++ b/GMI_GridComp/GmiChemistry/StratTrop_Orig/GMI_GridComp.rc
@@ -140,13 +140,22 @@ MEK_biom
 CO_biom
 NO_biom
 NO_air
+ALD2_biof
 ALK4_fosf
+ALK4_biof
 C2H6_fosf
+C2H6_biof
 PRPE_fosf
+PRPE_biof
 C3H8_fosf
+C3H8_biof
+CH2O_biof
 MEK_fosf
+MEK_biof
 CO_fosf
+CO_biof
 NO_fosf
+NO_biof
 ::
 
 emissionSpeciesLayers::
@@ -167,26 +176,50 @@ emissionSpeciesLayers::
 1
 1
 1
+1
+1
+1
+1
+1
+1
+1
+1
+1
 ::
+
+#emissionPointFilenames::
+#SO2:volcano:ExtData/chemistry/CARN/v202106/sfc/so2_volcanic_emissions_Carns.%y4%m2%d2.rc
+#::
+# NOTE: Units for the volcano point source files: kg(S)/s
+#       Units that GMI wants                    : kg(SO2)/s
+#       GMI does the conversion in Refresh_Daily within the Emission section
+# from GOCART2G SU (AMIP):
+#   ExtData/chemistry/CARN/v202106/sfc/so2_volcanic_emissions_Carns.%y4%m2%d2.rc
+# from GOCART2G SU (OPS):
+#   ExtData/chemistry/CARN/v202106/sfc/so2_volcanic_emissions_CARN_v202106.degassing_only.rc
+# includes eruptions:
+#   /discover/nobackup/projects/gmao/share/dao_ops/fvInput_nc3/PIESA/sfc/volcanic_v7/so2_volcanic_emissions_Carns.%y4%m2%d2.rc
+# does not include eruptions:
+#   /discover/nobackup/projects/gmao/share/dao_ops/fvInput_nc3/PIESA/sfc/volcanic_v7/so2_volcanic_effusive.v2.rc 
 
 # Ship Emissions requires SHIP_NO in ExtData:
 do_ShipEmission: T
 doMEGANemission: T
-doMEGANviaHEMCO: F
+doMEGANviaHEMCO: T
 
 isop_scale::
-1.0d0
-1.0d0
-1.0d0
-1.0d0
-1.0d0
-1.0d0
-1.0d0
-1.0d0
-1.0d0
-1.0d0
-1.0d0
-1.0d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
+0.7d0
 ::
 
 soil_infile_name:      ExtData/g5chem/x/GMI_SoilType.asc
@@ -247,7 +280,10 @@ forc_bc_kmax: 2
 #forc_bc_infile_name: /discover/nobackup/ldoman/fvInput/RCP6.0_5BrWMO2014_ch4latvar_1950_2100.asc
 #forc_bc_infile_name:              ExtData/g5chem/x/GMI/RCP6.0_5BrWMO2014_ch4latvar_1950_2100.asc
 #forc_bc_infile_name:              ExtData/g5chem/x/GMI/RCP6.0_5BrWMO2018_ch4latvar_1950_2100.asc
-forc_bc_infile_name:               ExtData/g5chem/x/GMI/ccmiRefD1_GMIbc_1950_2018.asc
+#forc_bc_infile_name:              ExtData/g5chem/x/GMI/ccmiRefD1_GMIbc_1950_2018.asc
+forc_bc_infile_name:  /discover/nobackup/projects/gmao/ccmdev/mmanyin/bench/GOLF/INPUT/BC/ccmiRefD1_GMIbc_plusHFC_extra5Br_1950_2018.asc
+
+#alternative /discover/nobackup/projects/gmi/gmidata2/users/steenrod/input/source_gas/RCP6.0_WMO2018_QingHFCs_ch4latvarGMDscl_1950_2022Hindcast.asc
 
 forcedBcSpeciesNames:: 
 CFC11
@@ -268,7 +304,18 @@ CH3Br
 CH3Cl
 CH4
 N2O
+xxx
+xxx
+xxx
+xxx
+xxx
+xxx
+xxx
+xxx
 ::
+
+# The xxx entries above are for HFC23 HFC32 HFC125 HFC134A HFC143A HFC152A SF6 and CO2
+
 
 #     ----------------------------------------------------
 #     sad_opt
@@ -356,8 +403,8 @@ do_ozone_inFastJX: F
 
 ## For FastJX 6.5 & JPL10
  fastj_opt: 4
-# cross_section_file: ExtData/g5chem/x/photolysis/FastJX_6.5/xsec_jx65_jpl10update2_JNOx1_0.dat
  cross_section_file: ExtData/g5chem/x/photolysis/FastJX_6.5/xsec_jx65wSO4_jpl10update2_JNOx1_0.dat
+# cross_section_file: ExtData/g5chem/x/photolysis/FastJX_6.5/xsec_jx65_jpl10update2_JNOx1_0.dat
 # rate_file not needed for FastJX6.5; new approach only differs by roundoff
 # rate_file: ExtData/g5chem/x/photolysis/FastJX/ratec_124spc_jx_gmiv2.dat
 # rate_file: ExtData/g5chem/x/photolysis/FastJX/ratec_119spc_jx_gmiv3.dat
@@ -399,7 +446,7 @@ FeedBack_QV: T
 NoPSCZone: 45
 PSC_Max_P_hPa: 175
 # Upper limit for HNO3COND [integer, ppbv]
-Condensed_HNO3_limit: 25
+Condensed_HNO3_limit: 75
 # Upper limit for HCl [real, ppbv]
 HCl_limit: 5.0
 

--- a/GMI_GridComp/GmiChemistry/StratTrop_Orig/GMI_GridComp.rc
+++ b/GMI_GridComp/GmiChemistry/StratTrop_Orig/GMI_GridComp.rc
@@ -205,7 +205,7 @@ emissionSpeciesLayers::
 # Ship Emissions requires SHIP_NO in ExtData:
 do_ShipEmission: T
 doMEGANemission: T
-doMEGANviaHEMCO: T
+doMEGANviaHEMCO: F
 
 isop_scale::
 0.7d0

--- a/GMI_GridComp/GmiDepos_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiDepos_GridCompClassMod.F90
@@ -711,11 +711,12 @@ CONTAINS
    CALL SatisfyImports(STATUS)
    VERIFY_(STATUS)
 
-! SZA
+! SZA (don't forget to take the cosine)
 ! ---
    call compute_SZA ( LONS=self%lonRad, LATS=self%latRad, ORBIT=self%orbit, &
                       CLOCK=self%clock, tdt=tdt, label='GMI-DEPOS', &
                       SZA=cosSolarZenithAngle, __RC__ )
+   cosSolarZenithAngle = COS( cosSolarZenithAngle * MAPL_DEGREES_TO_RADIANS )
 
 ! Hand the species concentrations to GMI's bundle
 ! -----------------------------------------------

--- a/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
@@ -1578,10 +1578,10 @@ CONTAINS
 
       IF(i <= self%num_diurnal_emiss) THEN
         weightedField2D(:,:) = PTR2D(:,:)*cellWeighting(:,:)
-        CALL Chem_BiomassDiurnal(var2D,                                     &
-                               weightedField2D(:,:),                        &
-                               self%lonRad(:,:)*MAPL_RADIANS_TO_DEGREES,    &
-                               self%latRad(:,:)*MAPL_RADIANS_TO_DEGREES,    &
+        CALL Chem_BiomassDiurnal(var2D,                                         &
+                               weightedField2D(:,:),                            &
+                               self%lonRad(:,:)*real(MAPL_RADIANS_TO_DEGREES),  &
+                               self%latRad(:,:)*real(MAPL_RADIANS_TO_DEGREES),  &
                                nhms, tdt)
         self%Emission%emissionArray(i)%pArray3D(:,:,1) = var2D(:,:)
       ELSE

--- a/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
@@ -1736,8 +1736,8 @@ CONTAINS
                 ebot = etop - (etop-ebot)/3.
               endif
 !... volcanic emissions are in kg(S), need kg(SO2)
-                CALL getMW(TRIM('EM_SO2'), itmp, mw, rc)
-                scale = mw/32.06
+              CALL getMW(TRIM('EM_SO2'), itmp, mw, rc)
+              scale = mw/32.06
             endif
 !
 !... distribute into column (z1 is gridbox top, z0 is gridbox bottom, arrays are bottom-up)

--- a/GMI_GridComp/GmiPhotolysis_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiPhotolysis_GridCompClassMod.F90
@@ -936,7 +936,7 @@ CONTAINS
          !=========
       end if
 
-      if ((self%phot_opt == 3)) then
+      if (self%phot_opt == 3) then
          Allocate(self%dust(i1:i2, ju1:j2, k1:k2, nSADdust))
          self%dust = 0.0d0
 
@@ -2362,49 +2362,55 @@ CONTAINS
       ! For the QJ Bundle
       !==================
 
-      call ESMF_StateGet(expChem, "gmiQJ", qjBundle, rc=STATUS)
-      VERIFY_(STATUS)
+      if (self%phot_opt /= 0) then
+        call ESMF_StateGet(expChem, "gmiQJ", qjBundle, rc=STATUS)
+        VERIFY_(STATUS)
 
-      call ESMF_FieldBundleGet(qjBundle, fieldCount=numVars, rc=STATUS)
-      VERIFY_(STATUS)
-      _ASSERT(numVars == self%num_qjo,'GMI qjo bundle populate')
+        call ESMF_FieldBundleGet(qjBundle, fieldCount=numVars, rc=STATUS)
+        VERIFY_(STATUS)
+        _ASSERT(numVars == self%num_qjo,'GMI qjo bundle populate')
 
-      do ib = 1, numVars
-         ptr3D(:,:,:) = self%qjgmi(ib)%pArray3D(:,:,km:1:-1)
-         call updateTracerToBundle(qjBundle, ptr3D, ib)
-      end do
+        do ib = 1, numVars
+           ptr3D(:,:,:) = self%qjgmi(ib)%pArray3D(:,:,km:1:-1)
+           call updateTracerToBundle(qjBundle, ptr3D, ib)
+        end do
+      end if
 
       !=====================
       ! For the tArea Bundle
       !=====================
 
-      call ESMF_StateGet(expChem, "gmiTAREA", tAreaBundle, rc=STATUS)
-      VERIFY_(STATUS)
+      if (self%phot_opt == 3) then
+        call ESMF_StateGet(expChem, "gmiTAREA", tAreaBundle, rc=STATUS)
+        VERIFY_(STATUS)
 
-      call ESMF_FieldBundleGet(tAreaBundle, fieldCount=numVars, rc=STATUS)
-      VERIFY_(STATUS)
-      _ASSERT(numVars == nSADdust+nSADaer,'GMI tArea bundle populate')
+        call ESMF_FieldBundleGet(tAreaBundle, fieldCount=numVars, rc=STATUS)
+        VERIFY_(STATUS)
+        _ASSERT(numVars == nSADdust+nSADaer,'GMI tArea bundle populate')
 
-      do ib = 1, numVars
-         ptr3D(:,:,:) = self%tArea(:,:,km:1:-1,ib)
-         call updateTracerToBundle(tAreaBundle, ptr3D, ib)
-      end do
+        do ib = 1, numVars
+           ptr3D(:,:,:) = self%tArea(:,:,km:1:-1,ib)
+           call updateTracerToBundle(tAreaBundle, ptr3D, ib)
+        end do
+      end if
 
       !=======================
       ! For the eRadius Bundle
       !=======================
 
-      call ESMF_StateGet(expChem, "gmiERADIUS", eRadiusBundle, rc=STATUS)
-      VERIFY_(STATUS)
+      if (self%phot_opt == 3) then
+        call ESMF_StateGet(expChem, "gmiERADIUS", eRadiusBundle, rc=STATUS)
+        VERIFY_(STATUS)
 
-      call ESMF_FieldBundleGet(eRadiusBundle, fieldCount=numVars, rc=STATUS)
-      VERIFY_(STATUS)
-      _ASSERT(numVars == nSADdust+nSADaer,'GMI eRadius bundle populate')
+        call ESMF_FieldBundleGet(eRadiusBundle, fieldCount=numVars, rc=STATUS)
+        VERIFY_(STATUS)
+        _ASSERT(numVars == nSADdust+nSADaer,'GMI eRadius bundle populate')
 
-      do ib = 1, numVars
-         ptr3D(:,:,:) = self%eRadius(:,:,km:1:-1,ib)
-         call updateTracerToBundle(eRadiusBundle, ptr3D, ib)
-      end do
+        do ib = 1, numVars
+           ptr3D(:,:,:) = self%eRadius(:,:,km:1:-1,ib)
+           call updateTracerToBundle(eRadiusBundle, ptr3D, ib)
+        end do
+      end if
 
       deallocate (ptr3D)
 
@@ -2658,6 +2664,8 @@ CONTAINS
 !...(if you prefer to use maximally overlapping clouds, remove the exponent)
               tau_clw(:,:,km:1:-1) = tauclw(:,:,1:km)*(fcld(:,:,1:km)**1.5)
               tau_cli(:,:,km:1:-1) = taucli(:,:,1:km)*(fcld(:,:,1:km)**1.5)
+!             tau_clw(:,:,km:1:-1) = tauclw(:,:,1:km)*(fcld(:,:,1:km)     )
+!             tau_cli(:,:,km:1:-1) = taucli(:,:,1:km)*(fcld(:,:,1:km)     )
 
             tau_cloud(:,:,:) = tau_clw(:,:,:) + tau_cli(:,:,:)
 


### PR DESCRIPTION
These updates were done to correct issues in CCM Benchmark G (GOLF).
They are non-zero-diff for GMI simulations.

Fixes:
- Fixed bug in Emissions and Deposition where SZA degrees was used instead of cosine(SZA)
- Fixed units for degassing volcano point emissions
- Improved handling of phot_opt cases; allows for phot_opt == 0 again
- Improved handling of sad_opt cases; allows for sad_opt == 0 again

Changes:
- Changed a few kcalc SAD reactions to use JPL 2019 approach
- ExtData now uses Benchmark G configuration
- Emissions including 2D, 3D and point source (volcano) now are done as in Benchmark G
- Isoprene scaling changed from 1 to 0.7
- Boundary condition file now includes HFCs, and no longer includes extra Br (when HFC mech is chosen)