### PR TITLE
Boundary conditions, automatic Bromine, and mods to HFC mech configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Capability to use 2D ExtData files as Boundary Conditions
 
 ### Changed
+
+- Changed the Monthly Wrap sampling (in ExtData yaml) to hold values constant for the month (zero diff, since DMS currently does not use that sampling)
+- Modified the starting date for several collections in ExtData yaml; now they cover a wider time range
+- Extended SO2 fire flux (ExtData yaml) to include future years from SSP2-4.5
+
 ### Removed
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Capability to use 2D ExtData files as Boundary Conditions
+- Added surface flux for CH2BR2 and CHBR3
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Capability to use 2D ExtData files as Boundary Conditions
-- Added surface flux for CH2BR2 and CHBR3
+- Added surface flux for CH2BR2 and CHBR3 in the HFC+S mechanism
+- Added an automatic Br adjustment, based on the species present in the mechanism. CH3Br and CH2Br2 are changed, either by adding to Forced BC's or by scaling Emissions.
 
 ### Changed
 
 - Changed the Monthly Wrap sampling (in ExtData yaml) to hold values constant for the month (zero diff, since DMS currently does not use that sampling)
 - Modified the starting date for several collections in ExtData yaml; now they cover a wider time range
 - Extended SO2 fire flux (ExtData yaml) to include future years from SSP2-4.5
+- Changed Forced Boundary Conditions to use the ExtData implementation by default (ASCII still supported); RefD1 and RefD2 BCs available via ExtData, use RefD2 by default.
+- Now automatically scale CH2Br2 emissions by 1.8, when using the HFC+S mechanism, to account for missing Br
 
 ### Removed
 ### Deprecated

--- a/GMI_GridComp/GMI_ExtData.yaml
+++ b/GMI_GridComp/GMI_ExtData.yaml
@@ -5,6 +5,9 @@ Collections:
 
   ## Monthly values
 
+  GMI_boundary_conds.monthly.1950-2018:                { valid_range: "1950-01-16T12:00/2018-12-16T12:00", template: /discover/nobackup/mmanyin/CCM/bc/GMI/BC.360x180/RefD1_plus_HFC/GMIbc_RefD1_plusHFC_noExtraBr.x360_y180_t12.%y4.L5.nc }
+  GMI_boundary_conds.monthly.1950-2100:                { valid_range: "1950-01-16T12:00/2100-12-16T12:00", template: /discover/nobackup/mmanyin/CCM/bc/GMI/BC.360x180/RefD2_plus_HFC/GMIbc_RefD2_plusHFC_noExtraBr.x360_y180_t12.%y4.L5.nc }
+
   GMI.CMIP6_BB.emis.monthly.1950-2015:                 { valid_range: "1950-01-16T00:00/2015-12-16T00:00", template: ExtData/CMIP6/sfc/biomass_burning/CMIP6_BB.emis.x1440_y720_t12.%y4.nc4 }
   GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100:          { valid_range: "2015-01-16T00:00/2100-12-16T00:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/sfc/CMIP6_BB.ssp2_45.emis.x720_y360_t12.%y4.nc4 }
 
@@ -264,3 +267,31 @@ Exports:
 
 # just for testing CH4 boundary conditions:
 # CH4_BC:                      { variable: CH4,                  collection: GMI.CH4_surf_values.monthly.2000-2009,                regrid: CONSERVE,  sample: GMI.daily_wrap        }
+
+  CFC11_BC:                    { variable: CFC11,                collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  CFC12_BC:                    { variable: CFC12,                collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  CFC113_BC:                   { variable: CFC113,               collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  CFC114_BC:                   { variable: CFC114,               collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  CFC115_BC:                   { variable: CFC115,               collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  CCl4_BC:                     { variable: CCl4,                 collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  CH3CCl3_BC:                  { variable: CH3CCl3,              collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  HCFC22_BC:                   { variable: HCFC22,               collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  HCFC141b_BC:                 { variable: HCFC141b,             collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  HCFC142b_BC:                 { variable: HCFC142b,             collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  CF2ClBr_BC:                  { variable: CF2ClBr,              collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  CF2Br2_BC:                   { variable: CF2Br2,               collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  CF3Br_BC:                    { variable: CF3Br,                collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  H2402_BC:                    { variable: H2402,                collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  CH3Br_BC:                    { variable: CH3Br,                collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily,            }
+  CH3Cl_BC:                    { variable: CH3Cl,                collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  CH4_BC:                      { variable: CH4,                  collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  N2O_BC:                      { variable: N2O,                  collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  HFC23_BC:                    { variable: HFC23,                collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  HFC32_BC:                    { variable: HFC32,                collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  HFC125_BC:                   { variable: HFC125,               collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  HFC134a_BC:                  { variable: HFC134a,              collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  HFC143a_BC:                  { variable: HFC143a,              collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  HFC152a_BC:                  { variable: HFC152a,              collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  SF6_BC:                      { variable: SF6,                  collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+  CO2_BC:                      { variable: CO2,                  collection: GMI_boundary_conds.monthly.1950-2100,                 regrid: CONSERVE,  sample: GMI.daily             }
+

--- a/GMI_GridComp/GMI_ExtData.yaml
+++ b/GMI_GridComp/GMI_ExtData.yaml
@@ -1,12 +1,9 @@
 Collections:
 
-  ## As used in GOLF (benchmark G)
-  ## Adapted from RefD2
-  ## New FF dataset includes fugitive emissions
+  ## GOLF (benchmark G)
+  ## Adapted from RefD2: new FF dataset includes fugitive emissions
 
   ## Monthly values
-
-  GMI.CH4_surf_values.monthly.2000-2009:               { valid_range: "2000-01-16T12:00/2009-12-16T12:00", template: /discover/nobackup/mmanyin/CCM/CH4/qOHreplay2.CH4_at_surface.%y4%m2.nc4 }
 
   GMI.CMIP6_BB.emis.monthly.1950-2015:                 { valid_range: "1950-01-16T00:00/2015-12-16T00:00", template: ExtData/CMIP6/sfc/biomass_burning/CMIP6_BB.emis.x1440_y720_t12.%y4.nc4 }
   GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100:          { valid_range: "2015-01-16T00:00/2100-12-16T00:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/sfc/CMIP6_BB.ssp2_45.emis.x720_y360_t12.%y4.nc4 }
@@ -31,34 +28,38 @@ Collections:
   ## (Now they continue with SSP2-4.5)
 
   # note: 2014 file for SSP245 is actually a pointer to CEDS
-  GMI.CMIP6_CEDS_AirSO2.emis.monthly.1950-2014:        { valid_range: "1950-01-15T12:00/2014-12-17T00:00", template: ExtData/CMIP6/L72/CMIP6_CEDS.airSO2emis.x720_y360_z72_t12.%y4.nc4 }
-  GMI.CMIP6_SSP245_AirSO2.emis.monthly.2014-2100:      { valid_range: "2014-01-15T12:00/2100-12-17T00:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/L72/CMIP6_SSP245.airSO2emis.x720_y360_z72_t12.%y4.nc4 }
+  GMI.CMIP6_CEDS_AirSO2.emis.monthly.1950-2014:          { valid_range: "1950-01-15T12:00/2014-12-17T00:00", template: ExtData/CMIP6/L72/CMIP6_CEDS.airSO2emis.x720_y360_z72_t12.%y4.nc4 }
+  GMI.CMIP6_SSP245_AirSO2.emis.monthly.2014-2100:        { valid_range: "2014-01-15T12:00/2100-12-17T00:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/L72/CMIP6_SSP245.airSO2emis.x720_y360_z72_t12.%y4.nc4 }
 
   # note: 2014 file for SSP245 is actually a pointer to CEDS
-  GMI.CMIP_CEDS_SO2_ENERGY.emis.monthly.1950-2014:     { valid_range: "1950-01-15T00:00/2014-12-16T12:00", template: ExtData/CMIP6/sfc/SU/SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__energy_elevated.x720_y360_t12.%y4.nc }
-  GMI.CMIP6_SSP245_SO2_ENERGY.emis.monthly.2014-2100:  { valid_range: "2014-01-15T00:00/2100-12-17T12:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/sfc/SU/CMIP6ssp245.emis_SO2.energy.x720_y360_t12.%y4.nc4 }
+  GMI.CMIP6_CEDS_SO2_ENERGY.emis.monthly.1950-2014:      { valid_range: "1950-01-15T00:00/2014-12-16T12:00", template: ExtData/CMIP6/sfc/SU/SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__energy_elevated.x720_y360_t12.%y4.nc }
+  GMI.CMIP6_SSP245_SO2_ENERGY.emis.monthly.2014-2100:    { valid_range: "2014-01-15T00:00/2100-12-17T12:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/sfc/SU/CMIP6ssp245.emis_SO2.energy.x720_y360_t12.%y4.nc4 }
 
   # note: 2014 file for SSP245 is actually a pointer to CEDS
-  GMI.CMIP_CEDS_SO2_NONENERGY.emis.monthly.1950-2014:  { valid_range: "1950-01-15T00:00/2014-12-16T12:00", template: ExtData/CMIP6/sfc/SU/SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__nonenergy_surface.x720_y360_t12.%y4.nc }
+  GMI.CMIP6_CEDS_SO2_NONENERGY.emis.monthly.1950-2014:   { valid_range: "1950-01-15T00:00/2014-12-16T12:00", template: ExtData/CMIP6/sfc/SU/SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__nonenergy_surface.x720_y360_t12.%y4.nc }
   GMI.CMIP6_SSP245_SO2_NONENERGY.emis.monthly.2014-2100: { valid_range: "2014-01-15T00:00/2100-12-17T12:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/sfc/SU/CMIP6ssp245.emis_SO2.sfcanthro.x720_y360_t12.%y4.nc4 }
 
   # note: 2014 file for SSP245 is actually a pointer to CEDS
-  GMI.CMIP_CEDS_SO2_SHIPPING.emis.monthly.1950-2014:   { valid_range: "1950-01-15T00:00/2014-12-16T12:00", template: ExtData/CMIP6/sfc/SU/SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__shipping_surface.x720_y360_t12.%y4.nc }
-  GMI.CMIP6_SSP245_SO2_SHIPPING.emis.monthly.2014-2100: { valid_range: "2014-01-15T00:00/2100-12-17T12:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/sfc/SU/CMIP6ssp245.emis_SO2.ships.x720_y360_t12.%y4.nc4 }
+  GMI.CMIP6_CEDS_SO2_SHIPPING.emis.monthly.1950-2014:    { valid_range: "1950-01-15T00:00/2014-12-16T12:00", template: ExtData/CMIP6/sfc/SU/SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-2017-05-18_gn__shipping_surface.x720_y360_t12.%y4.nc }
+  GMI.CMIP6_SSP245_SO2_SHIPPING.emis.monthly.2014-2100:  { valid_range: "2014-01-15T00:00/2100-12-17T12:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/sfc/SU/CMIP6ssp245.emis_SO2.ships.x720_y360_t12.%y4.nc4 }
 
   # three datasets that each cover decades
-  GMI.CMIP_SO2_BB.monthly.1750-2015:                   { valid_range: "1750-01-15T00:00/2015-12-16T12:00", template: ExtData/CMIP6/sfc/SU/SO2-em-biomassburning_input4MIPs_emissions_CMIP_VUA-CMIP-BB4CMIP6-1-2_gn__surface.x1440_y720_t12.%y4.nc }
-  GMI.GFEDv4_SO2_BB.monthly.1977-2019:                 { valid_range: "1997-01-15T12:00/2019-12-15T12:00", template: /discover/nobackup/sstrode/emissions/CCMI/RefD1emis/gfedv4_1s.emis_so2.x1152_y721_t240.19970115_12z_20191215_12z.nc }
-  GMI.CMIP6_SSP245_SO2_BB.emis.monthly.2015-2100:      { valid_range: "2015-01-16T00:00/2100-12-17T12:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/sfc/SU/CMIP6ssp245.emis_SO2.biomassburning.x720_y360_t12.%y4.nc4 }
+  GMI.CMIP6_SO2_BB.monthly.1750-2015:                    { valid_range: "1750-01-15T00:00/2015-12-16T12:00", template: ExtData/CMIP6/sfc/SU/SO2-em-biomassburning_input4MIPs_emissions_CMIP_VUA-CMIP-BB4CMIP6-1-2_gn__surface.x1440_y720_t12.%y4.nc }
+  GMI.GFEDv4_SO2_BB.monthly.1977-2019:                   { valid_range: "1997-01-15T12:00/2019-12-15T12:00", template: /discover/nobackup/sstrode/emissions/CCMI/RefD1emis/gfedv4_1s.emis_so2.x1152_y721_t240.19970115_12z_20191215_12z.nc }
+  GMI.CMIP6_SSP245_SO2_BB.emis.monthly.2015-2100:        { valid_range: "2015-01-16T00:00/2100-12-17T12:00", template: /discover/nobackup/projects/gmao/ccmdev/input/emissions/SSP/sfc/SU/CMIP6ssp245.emis_SO2.biomassburning.x720_y360_t12.%y4.nc4 }
 
-  GMI.ODS.emis.monthly.1951-2100:                      { valid_range: "1951-01-15T12:00/2100-12-17T00:00", template: /discover/nobackup/ssteenro/qing/SC.ODS.Emission.x360_y181.%y4.V1.nc }
+  GMI.ODS.emis.monthly.1951-2100:                        { valid_range: "1951-01-15T12:00/2100-12-17T00:00", template: /discover/nobackup/ssteenro/qing/SC.ODS.Emission.x360_y181.%y4.V1.nc }
+
+# just for testing CH4 boundary conditions:
+# GMI.CH4_surf_values.monthly.2000-2009:                 { valid_range: "2000-01-16T12:00/2009-12-16T12:00", template: /discover/nobackup/mmanyin/CCM/CH4/qOHreplay2.CH4_at_surface.%y4%m2.nc4 }
+
 
   ## Climatologies
 
   GMI.MEGAN_AEF_LAI.annual_clim:                       {                                                   template: ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc }  # just 1 time
 
-# GMI.DMS.monthly_clim:                                { valid_range: "1985-01-01T00:00/1985-12-01T00:00", template: /discover/nobackup/cakelle2/data/OCEAN/DMS_lana.geos.1x1.esmf.nc }
-  GMI.DMS.monthly_clim:                                { valid_range: "2011-01-14T12:00/2011-12-15T02:00", template: ExtData/chemistry/Lana/v2011/DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4 }
+# GMI.DMS.monthly_clim:                                { valid_range: "1985-01-01T00:00/1985-12-01T00:00", template: /discover/nobackup/cakelle2/data/OCEAN/DMS_lana.geos.1x1.esmf.nc }                    # kg/m3  0z day 1  values
+  GMI.DMS.monthly_clim:                                { valid_range: "2011-01-14T12:00/2011-12-15T02:00", template: ExtData/chemistry/Lana/v2011/DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4 }    # nmol/l mid-month values
   GMI.OCS.monthly_clim:                                { valid_range: "2016-01-15T12:00/2016-12-16T00:00", template: ExtData/g5chem/L72/OCS_vmr.x360_y181_z72.t12.2016.nc4 }
   GMI.ACET.monthly_clim:                               { valid_range: "2001-01-15T12:00/2001-12-17T00:00", template: ExtData/g5chem/L72/acetone_fixed_GMI.x288_y181_z72_t12.2001.nc }
   GMI.FERTILIZER.monthly_clim:                         { valid_range: "2006-01-15T12:00/2006-12-17T00:00", template: ExtData/g5chem/sfc/fertilizer_GMI.x288_y181_t12.2006.nc }
@@ -72,14 +73,14 @@ Samplings:
   GMI.daily_wrap:        { time_interpolation: true , update_frequency: PT24H,  update_offset: PT12H,  update_reference_time: '0', extrapolation: clim            } # Update every 0Z, interpolate the value for noon; wrap first or last year
   GMI.tdt_wrap:          { time_interpolation: true ,                                                                              extrapolation: clim            } # Update every timestep; wrap first or last year
   GMI.constant:          { time_interpolation: false,                                                                              extrapolation: persist_closest }
-  GMI.monthly_wrap:      { time_interpolation: false, update_frequency: P1M,                                                       extrapolation: clim            } # Update every month on day 1; wrap as clim
+  GMI.monthly_wrap:      { time_interpolation: false, update_frequency: P1M,                           update_reference_time: '0', extrapolation: clim            } # Update every month on day 1 and hold constant; wrap as clim
 
 Exports:
   ACET_FIXED:                  { variable: ACET,                 collection: GMI.ACET.monthly_clim,                                                   sample: GMI.daily_wrap        }
 
   ALD2_biof:
-    - { starting: "2000-01-01",  variable: ALD2_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
-    - { starting: "2015-01-01",  variable: ALD2_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "1950-01-01",  variable: ALD2_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2014-12-01",  variable: ALD2_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   ALD2_biom:
     - { starting: "1950-01-01",  variable: ALD2_bb,              collection: GMI.CMIP6_BB.emis.monthly.1950-2015,                  regrid: CONSERVE,  sample: GMI.daily_wrap        }
@@ -92,8 +93,8 @@ Exports:
     - { starting: "2015-12-01",  variable: ALK4_bb,              collection: GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   ALK4_fosf:
-    - { starting: "2000-01-01",  variable: ALK4_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
-    - { starting: "2015-01-01",  variable: ALK4_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "1950-01-01",  variable: ALK4_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2014-12-01",  variable: ALK4_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   C2H6_biof:                   {                                 collection: /dev/null                                                                                              }
 
@@ -102,8 +103,8 @@ Exports:
     - { starting: "2015-12-01",  variable: C2H6_bb,              collection: GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   C2H6_fosf:
-    - { starting: "2000-01-01",  variable: C2H6_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
-    - { starting: "2015-01-01",  variable: C2H6_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "1950-01-01",  variable: C2H6_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2014-12-01",  variable: C2H6_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   C3H8_biof:                   {                                 collection: /dev/null                                                                                              }
 
@@ -112,12 +113,12 @@ Exports:
     - { starting: "2015-12-01",  variable: C3H8_bb,              collection: GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   C3H8_fosf:
-    - { starting: "2000-01-01",  variable: C3H8_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
-    - { starting: "2015-01-01",  variable: C3H8_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "1950-01-01",  variable: C3H8_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2014-12-01",  variable: C3H8_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   CH2O_biof:
-    - { starting: "2000-01-01",  variable: CH2O_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
-    - { starting: "2015-01-01",  variable: CH2O_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "1950-01-01",  variable: CH2O_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2014-12-01",  variable: CH2O_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   CH2O_biom:
     - { starting: "1950-01-01",  variable: CH2O_bb,              collection: GMI.CMIP6_BB.emis.monthly.1950-2015,                  regrid: CONSERVE,  sample: GMI.daily_wrap        }
@@ -134,8 +135,8 @@ Exports:
     - { starting: "2015-12-01",  variable: CO_bb,                collection: GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   CO_fosf:
-    - { starting: "2000-01-01",  variable: CO_ff,                collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
-    - { starting: "2015-01-01",  variable: CO_ff,                collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "1950-01-01",  variable: CO_ff,                collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2014-12-01",  variable: CO_ff,                collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   MEK_biof:                    {                                 collection: /dev/null                                                                                              }
 
@@ -144,8 +145,8 @@ Exports:
     - { starting: "2015-12-01",  variable: MEK_bb,               collection: GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   MEK_fosf:
-    - { starting: "2000-01-01",  variable: MEK_ff,               collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
-    - { starting: "2015-01-01",  variable: MEK_ff,               collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "1950-01-01",  variable: MEK_ff,               collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2014-12-01",  variable: MEK_ff,               collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   NO_air:
     - { starting: "1950-01-01",  variable: NO_air,               collection: GMI.CMIP6_CEDS_AirNO.emis.monthly.1950-2014,          regrid: CONSERVE,  sample: GMI.daily_wrap        }
@@ -158,8 +159,8 @@ Exports:
     - { starting: "2015-12-01",  variable: NO_bb,                collection: GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   NO_fosf:
-    - { starting: "2000-01-01",  variable: NO_ff,                collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
-    - { starting: "2015-01-01",  variable: NO_ff,                collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "1950-01-01",  variable: NO_ff,                collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2014-12-01",  variable: NO_ff,                collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
 
   NO_pwrp:                     {                                 collection: /dev/null                                                                                              }
@@ -172,8 +173,8 @@ Exports:
     - { starting: "2015-12-01",  variable: PRPE_bb,              collection: GMI.CMIP6_BB_SSP245.emis.monthly.2015-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   PRPE_fosf:
-    - { starting: "2000-01-01",  variable: PRPE_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
-    - { starting: "2015-01-01",  variable: PRPE_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "1950-01-01",  variable: PRPE_ff,              collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2014-12-01",  variable: PRPE_ff,              collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   CCL4_FLUX:                   { variable:      CCL4_emission,   collection: GMI.ODS.emis.monthly.1951-2100,                       regrid: CONSERVE,  sample: GMI.daily             }
   CFC113_FLUX:                 { variable:    CFC113_emission,   collection: GMI.ODS.emis.monthly.1951-2100,                       regrid: CONSERVE,  sample: GMI.daily             }
@@ -189,20 +190,22 @@ Exports:
 
   SO2_AIRCRAFT-FLUX:
     - { starting: "1950-01-01",  variable: SO2_aviation,         collection: GMI.CMIP6_CEDS_AirSO2.emis.monthly.1950-2014,         regrid: CONSERVE,  sample: GMI.daily_wrap        }
-    - { starting: "2014-12-01",  variable: SO2_aviation,         collection: GMI.CMIP6_SSP245_AirSO2.emis.monthly.2014-2100,       regrid: CONSERVE,  sample: GMI.daily_wrap        }  # 2020
+    - { starting: "2014-12-01",  variable: SO2_aviation,         collection: GMI.CMIP6_SSP245_AirSO2.emis.monthly.2014-2100,       regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   SO2_ENERGY-FLUX:
-    - { starting: "1950-01-01",  variable: SO2_energy,           collection: GMI.CMIP_CEDS_SO2_ENERGY.emis.monthly.1950-2014,      regrid: CONSERVE,  sample: GMI.daily_wrap        }
-    - { starting: "2014-12-01",  variable: SO2_energy,           collection: GMI.CMIP6_SSP245_SO2_ENERGY.emis.monthly.2014-2100,   regrid: CONSERVE,  sample: GMI.daily_wrap        }  # 2020
+    - { starting: "1950-01-01",  variable: SO2_energy,           collection: GMI.CMIP6_CEDS_SO2_ENERGY.emis.monthly.1950-2014,     regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2014-12-01",  variable: SO2_energy,           collection: GMI.CMIP6_SSP245_SO2_ENERGY.emis.monthly.2014-2100,   regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
-  SO2_FIRES-FLUX:              { variable: SO2,                  collection: GMI.CMIP_SO2_BB.monthly.1750-2015,                    regrid: CONSERVE,  sample: GMI.daily_wrap        }  # last full year is 2015
+  SO2_FIRES-FLUX:
+    - { starting: "1750-01-15",  variable: SO2,                  collection: GMI.CMIP6_SO2_BB.monthly.1750-2015,                   regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2015-12-01",  variable: biomass,              collection: GMI.CMIP6_SSP245_SO2_BB.emis.monthly.2015-2100,       regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   SO2_NONENERGY-FLUX:
-    - { starting: "1950-01-01",  variable: SO2_nonenergy,        collection: GMI.CMIP_CEDS_SO2_NONENERGY.emis.monthly.1950-2014,   regrid: CONSERVE,  sample: GMI.daily_wrap        }
-    - { starting: "2014-12-01",  variable: SO2_nonenergy,        collection: GMI.CMIP6_SSP245_SO2_NONENERGY.emis.monthly.2014-2100, regrid: CONSERVE,  sample: GMI.daily_wrap        }  # 2020
+    - { starting: "1950-01-01",  variable: SO2_nonenergy,        collection: GMI.CMIP6_CEDS_SO2_NONENERGY.emis.monthly.1950-2014,   regrid: CONSERVE, sample: GMI.daily_wrap        }
+    - { starting: "2014-12-01",  variable: SO2_nonenergy,        collection: GMI.CMIP6_SSP245_SO2_NONENERGY.emis.monthly.2014-2100, regrid: CONSERVE, sample: GMI.daily_wrap        }
 
   SO2_SHIPPING-FLUX:
-    - { starting: "1950-01-01",  variable: SO2_shipping,         collection: GMI.CMIP_CEDS_SO2_SHIPPING.emis.monthly.1950-2014,    regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "1950-01-01",  variable: SO2_shipping,         collection: GMI.CMIP6_CEDS_SO2_SHIPPING.emis.monthly.1950-2014,   regrid: CONSERVE,  sample: GMI.daily_wrap        }
     - { starting: "2014-12-01",  variable: SO2_shipping,         collection: GMI.CMIP6_SSP245_SO2_SHIPPING.emis.monthly.2014-2100, regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
 # DMS_OCEAN:                   { variable: DMS_OCEAN,            collection: GMI.DMS.monthly_clim,                                 regrid: CONSERVE,  sample: GMI.monthly_wrap      }
@@ -217,8 +220,8 @@ Exports:
     - { starting: "2023-12-01",  variable: lbssad,               collection: GMI.CMIP6_SAD.monthly_clim,                                              sample: GMI.daily_wrap        }
 
   SHIP_NO:
-    - { starting: "2000-01-01",  variable: NO_shp,               collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
-    - { starting: "2015-01-01",  variable: NO_shp,               collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "1950-01-01",  variable: NO_shp,               collection: GMI.CMIP6_CEDS.emis_fg.monthly.1950-2014,             regrid: CONSERVE,  sample: GMI.daily_wrap        }
+    - { starting: "2014-12-01",  variable: NO_shp,               collection: GMI.CMIP6_SSP245.emis_fg.monthly.2014-2100,           regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
   SOILFERT:                    { variable: soilFert,             collection: GMI.FERTILIZER.monthly_clim,                          regrid: CONSERVE,  sample: GMI.daily_wrap        }
   SOILPRECIP:                  { variable: soilPrecip,           collection: GMI.PRECIP.monthly_clim,                                                 sample: GMI.daily_wrap        }
@@ -259,4 +262,5 @@ Exports:
   du004:                       { variable: DU004,                collection: GMI.aero_MERRA2.monthly_clim,                         regrid: CONSERVE,  sample: GMI.daily_wrap        }
   du005:                       { variable: DU005,                collection: GMI.aero_MERRA2.monthly_clim,                         regrid: CONSERVE,  sample: GMI.daily_wrap        }
 
-  CH4_BC:                      { variable: CH4,                  collection: GMI.CH4_surf_values.monthly.2000-2009,                regrid: CONSERVE,  sample: GMI.daily_wrap        }
+# just for testing CH4 boundary conditions:
+# CH4_BC:                      { variable: CH4,                  collection: GMI.CH4_surf_values.monthly.2000-2009,                regrid: CONSERVE,  sample: GMI.daily_wrap        }

--- a/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_GridComp.rc
+++ b/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_GridComp.rc
@@ -161,6 +161,8 @@ SO2_NONENERGY-FLUX
 SO2_ENERGY-FLUX
 SO2_SHIPPING-FLUX
 SO2_AIRCRAFT-FLUX
+CH2BR2_FLUX
+CHBR3_FLUX
 ::
 
 emissionSpeciesLayers::
@@ -195,6 +197,8 @@ emissionSpeciesLayers::
 1
 1
 72
+1
+1
 ::
 
 emissionPointFilenames::

--- a/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_GridComp.rc
+++ b/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_GridComp.rc
@@ -301,6 +301,43 @@ forc_bc_infile_name:  /discover/nobackup/projects/gmao/ccmdev/mmanyin/bench/GOLF
 #alternative /discover/nobackup/projects/gmi/gmidata2/users/steenrod/input/source_gas/RCP6.0_WMO2018_QingHFCs_ch4latvarGMDscl_1950_2022Hindcast.asc
 
 forcedBcSpeciesNames:: 
+#CFC11
+#CFC12
+#CFC113
+#CFC114
+#CFC115
+#CCl4
+#CH3CCl3
+#HCFC22
+#HCFC141b
+#HCFC142b
+#CF2ClBr
+#CF2Br2
+#CF3Br
+#H2402
+#CH3Br
+#CH3Cl
+#CH4
+#N2O
+#HFC23
+#HFC32
+#HFC125
+#HFC134A
+#HFC143A
+#HFC152A
+#xxx
+#xxx
+::
+
+# The xxx entries above are for SF6 and CO2
+
+        ###########################################################
+        # GHG and ODS surface source gases - read with ExtData
+        # (import name = <species_name>_BC )
+        ###########################################################
+ext_bc_kmin: 1
+ext_bc_kmax: 2
+extdataBcSpeciesNames:: 
 CFC11
 CFC12
 CFC113
@@ -322,22 +359,11 @@ N2O
 HFC23
 HFC32
 HFC125
-HFC134A
-HFC143A
-HFC152A
-xxx
-xxx
-::
-
-# The xxx entries above are for SF6 and CO2
-
-        ###########################################################
-        # GHG and ODS surface source gases - read with ExtData
-        ###########################################################
-ext_bc_kmin: 1
-ext_bc_kmax: 2
-extdataBcSpeciesNames:: 
-#CH4
+HFC134a
+HFC143a
+HFC152a
+# SF6
+# CO2
 ::
 
 

--- a/GMI_GridComp/GmiChemistry/StratTrop_Orig/GMI_GridComp.rc
+++ b/GMI_GridComp/GmiChemistry/StratTrop_Orig/GMI_GridComp.rc
@@ -281,11 +281,49 @@ forc_bc_kmax: 2
 #forc_bc_infile_name:              ExtData/g5chem/x/GMI/RCP6.0_5BrWMO2014_ch4latvar_1950_2100.asc
 #forc_bc_infile_name:              ExtData/g5chem/x/GMI/RCP6.0_5BrWMO2018_ch4latvar_1950_2100.asc
 #forc_bc_infile_name:              ExtData/g5chem/x/GMI/ccmiRefD1_GMIbc_1950_2018.asc
-forc_bc_infile_name:  /discover/nobackup/projects/gmao/ccmdev/mmanyin/bench/GOLF/INPUT/BC/ccmiRefD1_GMIbc_plusHFC_extra5Br_1950_2018.asc
+#forc_bc_infile_name:  /discover/nobackup/projects/gmao/ccmdev/mmanyin/bench/GOLF/INPUT/BC/ccmiRefD1_GMIbc_plusHFC_extra5Br_1950_2018.asc
+forc_bc_infile_name:  /discover/nobackup/projects/gmao/ccmdev/mmanyin/bench/GOLF/INPUT/BC/ccmiRefD1_GMIbc_plusHFC_no5Br_1950_2018.asc
 
 #alternative /discover/nobackup/projects/gmi/gmidata2/users/steenrod/input/source_gas/RCP6.0_WMO2018_QingHFCs_ch4latvarGMDscl_1950_2022Hindcast.asc
 
 forcedBcSpeciesNames:: 
+#CFC11
+#CFC12
+#CFC113
+#CFC114
+#CFC115
+#CCl4
+#CH3CCl3
+#HCFC22
+#HCFC141b
+#HCFC142b
+#CF2ClBr
+#CF2Br2
+#CF3Br
+#H2402
+#CH3Br
+#CH3Cl
+#CH4
+#N2O
+#xxx
+#xxx
+#xxx
+#xxx
+#xxx
+#xxx
+#xxx
+#xxx
+::
+
+# The xxx entries above are for HFC23 HFC32 HFC125 HFC134a HFC143a HFC152a SF6 and CO2
+
+        ###########################################################
+        # GHG and ODS surface source gases - read with ExtData
+        # (import name = <species_name>_BC )
+        ###########################################################
+ext_bc_kmin: 1
+ext_bc_kmax: 2
+extdataBcSpeciesNames:: 
 CFC11
 CFC12
 CFC113
@@ -304,25 +342,14 @@ CH3Br
 CH3Cl
 CH4
 N2O
-xxx
-xxx
-xxx
-xxx
-xxx
-xxx
-xxx
-xxx
-::
-
-# The xxx entries above are for HFC23 HFC32 HFC125 HFC134A HFC143A HFC152A SF6 and CO2
-
-        ###########################################################
-        # GHG and ODS surface source gases - read with ExtData
-        ###########################################################
-ext_bc_kmin: 1
-ext_bc_kmax: 2
-extdataBcSpeciesNames:: 
-#CH4
+# HFC23
+# HFC32
+# HFC125
+# HFC134a
+# HFC143a
+# HFC152a
+# SF6
+# CO2
 ::
 
 

--- a/GMI_GridComp/GmiShared/GmiSupportingModules/GmiBCandFluxAdjust_mod.F90
+++ b/GMI_GridComp/GmiShared/GmiSupportingModules/GmiBCandFluxAdjust_mod.F90
@@ -99,34 +99,34 @@ module GmiBCandFluxAdjust_mod
 !...  CHBrCl2 - subtract 0.3 from CH2Br2 extra 1 ppt
 !...  CH2BrCl - subtract 0.1 from CH2Br2 extra 1 ppt
       if(ich3br .gt. 0) then
-         add_ch3br = 5.0d-12
+        add_ch3br  = 5.0d-12
         mult_ch3br = -999.0 * 1.0d0     ! need value for this
         if(ichbr3 .gt. 0) then
-           add_ch3br = add_ch3br-3.6d-12
+          add_ch3br  = add_ch3br-3.6d-12
           mult_ch3br = -999.0 * 1.0d0   ! need value for this
           if(ich2br2 .gt. 0) then
-             add_ch3br = 0.0d-12
+            add_ch3br  = 0.0d-12
             mult_ch3br = 1.0d0
-             add_ch2br2 = 1.0d-12   ! NOTE: Only used if CH2Br2 is a Forced Boundary Condition
+            add_ch2br2  = 1.0d-12   ! NOTE: Only used if CH2Br2 is a Forced Boundary Condition
             mult_ch2br2 = 1.8d0     ! NOTE: Only used if CH2Br2 is an Emission  [Qing email 4/3/24]
 !... other VSLBr species that could be included (CHBr2Cl, CHBrCl2, CH2BrCl)
               if(ichbr2cl .gt. 0) then
                 PRINT*,TRIM(Iam)//' Running a new section of code, please review it'
                 PRINT*, " "
                 VERIFY_(101)
-                 add_ch2br2 = add_ch2br2-0.6d-12
+                add_ch2br2  = add_ch2br2-0.6d-12
                 mult_ch2br2 = -999.0 * 1.0d0   ! need value for this
                 if(ichbrcl2 .gt. 0) then
                   PRINT*,TRIM(Iam)//' Running a new section of code, please review it'
                   PRINT*, " "
                   VERIFY_(102)
-                   add_ch2br2 = add_ch2br2-0.3d-12
+                  add_ch2br2  = add_ch2br2-0.3d-12
                   mult_ch2br2 = -999.0 * 1.0d0   ! need value for this
                   if(ich2brcl .gt. 0) then
                     PRINT*,TRIM(Iam)//' Running a new section of code, please review it'
                     PRINT*, " "
                     VERIFY_(103)
-                     add_ch2br2 = add_ch2br2-0.1d-12
+                    add_ch2br2  = add_ch2br2-0.1d-12
                     mult_ch2br2 = -999.0 * 1.0d0   ! need value for this
                   endif
                 endif

--- a/GMI_GridComp/GmiShared/GmiSupportingModules/GmiBCandFluxAdjust_mod.F90
+++ b/GMI_GridComp/GmiShared/GmiSupportingModules/GmiBCandFluxAdjust_mod.F90
@@ -1,0 +1,151 @@
+#include "MAPL_Generic.h"
+
+module GmiBCandFluxAdjust_mod
+
+    use ESMF
+    use MAPL
+    use GmiSpeciesRegistry_mod,        only : getSpeciesIndex
+
+    implicit none
+
+    INTEGER, PARAMETER :: DBL = KIND(0.00D+00)
+
+    private
+    public  :: GetBrAdjustments
+
+!=============================================================================
+!
+! CODE DEVELOPERS
+!   Steve Steenrod  NASA/GSFC Code 614
+!   Mike Manyin     NASA/GSFC Code 614
+!
+!=============================================================================
+
+     contains
+
+!-----------------------------------------------------------------------------
+!
+! ROUTINE
+!   GetBrAdjustments
+!
+! DESCRIPTION
+!   This routine ...
+!
+! ARGUMENTS
+!
+!-----------------------------------------------------------------------------
+
+      subroutine GetBrAdjustments           (  &
+           add_ch3br_opt,   add_ch2br2_opt,    &
+          mult_ch3br_opt,  mult_ch2br2_opt,    &
+          rc                                )
+
+!     ----------------------
+!     Argument declarations.
+!     ----------------------
+
+      real(kind=DBL), optional, intent(out)  ::   add_ch3br_opt,   add_ch2br2_opt  ! Suitable for Forced Boundary Conditions
+      real(kind=DBL), optional, intent(out)  ::  mult_ch3br_opt,  mult_ch2br2_opt  ! Suitable for Flux   Boundary Conditions
+      integer,        optional, intent(out)  ::  rc                                ! Error return code
+
+
+!     ----------------------
+!     Variable declarations.
+!     ----------------------
+
+      character(len=*), parameter :: IAm = 'GetBrAdjustments'
+
+      integer        :: ich3br
+      integer        :: ichbr3
+      integer        :: ich2br2
+      integer        :: ichbr2cl
+      integer        :: ichbrcl2
+      integer        :: ich2brcl
+
+      real(kind=DBL) ::     add_ch3br,  add_ch2br2
+      real(kind=DBL) ::    mult_ch3br, mult_ch2br2
+
+
+!     ----------
+!     Initialize
+!     ----------
+      add_ch3br    = 0.0d0
+      add_ch2br2   = 0.0d0
+      mult_ch3br   = 1.0d0
+      mult_ch2br2  = 1.0d0
+
+
+!... Because we have mechanisms with incomplete VSLBr species
+!... we need to compensate in other VSLBr species, for now CH3Br and CH2Br2
+      ich3br   = getSpeciesIndex('CH3Br',  .TRUE.)   ! .TRUE. arg=>don't error exit if species not there
+      ichbr3   = getSpeciesIndex('CHBr3',  .TRUE.)
+      ich2br2  = getSpeciesIndex('CH2Br2', .TRUE.)
+!... other VSLBr species that could be included in a future mechanism
+      ichbr2cl = getSpeciesIndex('CHBr2Cl',.TRUE.)
+      ichbrcl2 = getSpeciesIndex('CHBrCl2',.TRUE.)
+      ich2brcl = getSpeciesIndex('CH2BrCl',.TRUE.)
+
+
+
+
+!... Because we have mechanisms with incomplete VSLBr chemistry
+!...  we need to compensate in the other existing VSLBr species if they are fixed BCs
+!... species importance in order:
+!... (assume that species will be added in this order)
+!...  CH3Br   - unless have CHBr3 and CH2Br2 in mech, add extra 5.0 ppt
+!...  CHBr3   - subtract 3.6 from CH3Br's extra 5 ppt
+!...  CH2Br2  - make CH3Br extra 0 ppt and add extra 1 ppt to CH2Br2
+!...  CHBr2Cl - subtract 0.6 from CH2Br2 extra 1 ppt
+!...  CHBrCl2 - subtract 0.3 from CH2Br2 extra 1 ppt
+!...  CH2BrCl - subtract 0.1 from CH2Br2 extra 1 ppt
+      if(ich3br .gt. 0) then
+         add_ch3br = 5.0d-12
+        mult_ch3br = -999.0 * 1.0d0     ! need value for this
+        if(ichbr3 .gt. 0) then
+           add_ch3br = add_ch3br-3.6d-12
+          mult_ch3br = -999.0 * 1.0d0   ! need value for this
+          if(ich2br2 .gt. 0) then
+             add_ch3br = 0.0d-12
+            mult_ch3br = 1.0d0
+             add_ch2br2 = 1.0d-12   ! NOTE: Only used if CH2Br2 is a Forced Boundary Condition
+            mult_ch2br2 = 1.8d0     ! NOTE: Only used if CH2Br2 is an Emission  [Qing email 4/3/24]
+!... other VSLBr species that could be included (CHBr2Cl, CHBrCl2, CH2BrCl)
+              if(ichbr2cl .gt. 0) then
+                PRINT*,TRIM(Iam)//' Running a new section of code, please review it'
+                PRINT*, " "
+                VERIFY_(101)
+                 add_ch2br2 = add_ch2br2-0.6d-12
+                mult_ch2br2 = -999.0 * 1.0d0   ! need value for this
+                if(ichbrcl2 .gt. 0) then
+                  PRINT*,TRIM(Iam)//' Running a new section of code, please review it'
+                  PRINT*, " "
+                  VERIFY_(102)
+                   add_ch2br2 = add_ch2br2-0.3d-12
+                  mult_ch2br2 = -999.0 * 1.0d0   ! need value for this
+                  if(ich2brcl .gt. 0) then
+                    PRINT*,TRIM(Iam)//' Running a new section of code, please review it'
+                    PRINT*, " "
+                    VERIFY_(103)
+                     add_ch2br2 = add_ch2br2-0.1d-12
+                    mult_ch2br2 = -999.0 * 1.0d0   ! need value for this
+                  endif
+                endif
+              endif
+          endif
+        endif
+      endif
+
+!     ---------------------------
+!     Fill the Optional Arguments
+!     ---------------------------
+      if ( present(add_ch3br_opt  ) )  add_ch3br_opt   = add_ch3br
+      if ( present(add_ch2br2_opt ) )  add_ch2br2_opt  = add_ch2br2
+      if ( present(mult_ch3br_opt ) )  mult_ch3br_opt  = mult_ch3br
+      if ( present(mult_ch2br2_opt) )  mult_ch2br2_opt = mult_ch2br2
+
+      if ( present(rc) ) rc = ESMF_SUCCESS
+      return
+
+      end subroutine GetBrAdjustments
+
+end module GmiBCandFluxAdjust_mod

--- a/GMI_GridComp/GmiShared/GmiSupportingModules/GmiSpeciesRegistry_mod.F90
+++ b/GMI_GridComp/GmiShared/GmiSupportingModules/GmiSpeciesRegistry_mod.F90
@@ -105,7 +105,7 @@
  endif
 !
  if (index == UNKNOWN_SPECIES) then
-    err_msg = 'The species does not exist: '// name
+    err_msg = 'The species does not exist: "'// TRIM(name) // '"'
     call GmiPrintError(err_msg, .true., 1, index, 0, 0, 0.0d0, 0.0d0)
  end if
 


### PR DESCRIPTION
* Forced Boundary Conditions are now read in using ExtData by default; files for RefD1 and RefD2 are available. With interpolation applied to mid-month values, the effects are non-zero-diff.
* Extra Bromine used to be included in CH3Br in the Forced BoCo ASCII file; this was only done for the Original Mech. The Bromine is now added automatically, based on which species are present in the mechanism. For the Orig Mech, 5ppt is added to CH3Br Forced BoCo. For the HFC+S Mech, the CH2Br2 emissions are scaled by 1.8 . The latter change is a non-zero difference. 
* Surface flux was added for CH2Br2 and CHBr3 in the HFC+S mech configuration. This corrects an oversight.