### PR TITLE
Improve convergence in Solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+
+- Set the reaction rates for certain ICE and NAT and STS reactions to zero when HCl < min-concentation; this helps prevent HCl problems.
+
 ### Added
 
 - Capability to use 2D ExtData files as Boundary Conditions
@@ -21,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extended SO2 fire flux (ExtData yaml) to include future years from SSP2-4.5
 - Changed Forced Boundary Conditions to use the ExtData implementation by default (ASCII still supported); RefD1 and RefD2 BCs available via ExtData, use RefD2 by default.
 - Now automatically scale CH2Br2 emissions by 1.8, when using the HFC+S mechanism, to account for missing Br
+- Changed the tolerance for the SMV Gear solver; this helps with convergence
 
 ### Removed
 ### Deprecated

--- a/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/setkin_kcalc.F90
+++ b/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/setkin_kcalc.F90
@@ -2465,7 +2465,7 @@
           where( hcl > minconc )
             sksts_clono2_hcl = 0.25d0 * gprob_hcl * avgvel * sad / hcl
           elsewhere
-            sksts_clono2_hcl = 0.25d0 * gprob_hcl * avgvel * sad
+            sksts_clono2_hcl = 0.0d0
           end where
 !
           where( sad < 0.0d0 ) sksts_clono2_hcl = 0.0d0
@@ -2621,7 +2621,7 @@
           where( hcl > minconc )
             sksts_hocl_hcl = 0.25d0 * gprob_tot * avgvel * sad / hcl
           elsewhere
-            sksts_hocl_hcl = 0.25d0 * gprob_tot * avgvel * sad
+            sksts_hocl_hcl = 0.0d0
           end where
 !
           where( sad < 0.0d0 ) sksts_hocl_hcl   = 0.0d0
@@ -2735,7 +2735,7 @@
           where( hcl > minconc )
             sksts_hobr_hcl = 0.25d0 * gprob_tot * avgvel * sad / hcl
          elsewhere
-            sksts_hobr_hcl = 0.25d0 * gprob_tot * avgvel * sad
+            sksts_hobr_hcl = 0.0d0
          end where
 !
           where( sad < 0.0d0 ) sksts_hobr_hcl = 0.0d0
@@ -2846,7 +2846,7 @@
           sknat_hcl_clono2(:) = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
-            sknat_hcl_clono2  = sknat_hcl_clono2 / minconc
+            sknat_hcl_clono2  = 0.0d0
           elsewhere
             sknat_hcl_clono2  = sknat_hcl_clono2 / hcl
           end where
@@ -2886,7 +2886,7 @@
           sknat_hcl_hocl(:) = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
-            sknat_hcl_hocl  = sknat_hcl_hocl / minconc
+            sknat_hcl_hocl  = 0.0d0
           elsewhere
             sknat_hcl_hocl  = sknat_hcl_hocl / hcl
           end where
@@ -2926,7 +2926,7 @@
           sknat_hcl_brono2(:) = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
-            sknat_hcl_brono2  = sknat_hcl_brono2 / minconc
+            sknat_hcl_brono2  = 0.0d0
           elsewhere
             sknat_hcl_brono2  = sknat_hcl_brono2 / hcl
           end where
@@ -2966,7 +2966,7 @@
           sknat_hcl_hobr(:) = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
-            sknat_hcl_hobr  = sknat_hcl_hobr / minconc
+            sknat_hcl_hobr  = 0.0d0
           elsewhere
             sknat_hcl_hobr  = sknat_hcl_hobr / hcl
           end where
@@ -3077,7 +3077,7 @@
           skice_hcl_clono2(:)  = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
-            skice_hcl_clono2   = skice_hcl_clono2 / minconc
+            skice_hcl_clono2   = 0.0d0
           elsewhere
             skice_hcl_clono2   = skice_hcl_clono2 / hcl
           end where
@@ -3119,7 +3119,7 @@
           skice_hcl_hocl(:)  = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
-            skice_hcl_hocl   = skice_hcl_hocl / minconc
+            skice_hcl_hocl   = 0.0d0
           elsewhere
             skice_hcl_hocl   = skice_hcl_hocl / hcl
           end where
@@ -3162,7 +3162,7 @@
           skice_hcl_brono2(:)  = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
-            skice_hcl_brono2   = skice_hcl_brono2 / minconc
+            skice_hcl_brono2   = 0.0d0
           elsewhere
             skice_hcl_brono2   = skice_hcl_brono2 / hcl
           end where
@@ -3204,7 +3204,7 @@
           skice_hcl_hobr(:)  = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
-            skice_hcl_hobr   = skice_hcl_hobr / minconc
+            skice_hcl_hobr   = 0.0d0
           elsewhere
             skice_hcl_hobr   = skice_hcl_hobr / hcl
           end where

--- a/GMI_GridComp/GmiChemistry/StratTrop_Orig/setkin_kcalc.F90
+++ b/GMI_GridComp/GmiChemistry/StratTrop_Orig/setkin_kcalc.F90
@@ -2384,7 +2384,7 @@
           where( hcl > minconc )
             sksts_clono2_hcl = 0.25d0 * gprob_hcl * avgvel * sad / hcl
           elsewhere
-            sksts_clono2_hcl = 0.25d0 * gprob_hcl * avgvel * sad
+            sksts_clono2_hcl = 0.0d0
           end where
 !
           where( sad < 0.0d0 ) sksts_clono2_hcl = 0.0d0
@@ -2540,7 +2540,7 @@
           where( hcl > minconc )
             sksts_hocl_hcl = 0.25d0 * gprob_tot * avgvel * sad / hcl
           elsewhere
-            sksts_hocl_hcl = 0.25d0 * gprob_tot * avgvel * sad
+            sksts_hocl_hcl = 0.0d0
           end where
 !
           where( sad < 0.0d0 ) sksts_hocl_hcl   = 0.0d0
@@ -2654,7 +2654,7 @@
           where( hcl > minconc )
             sksts_hobr_hcl = 0.25d0 * gprob_tot * avgvel * sad / hcl
          elsewhere
-            sksts_hobr_hcl = 0.25d0 * gprob_tot * avgvel * sad
+            sksts_hobr_hcl = 0.0d0
          end where
 !
           where( sad < 0.0d0 ) sksts_hobr_hcl = 0.0d0
@@ -2766,7 +2766,7 @@
           sknat_hcl_clono2(:) = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
-            sknat_hcl_clono2  = sknat_hcl_clono2 / minconc
+            sknat_hcl_clono2  = 0.0d0
           elsewhere
             sknat_hcl_clono2  = sknat_hcl_clono2 / hcl
           end where
@@ -2807,7 +2807,7 @@
           sknat_hcl_hocl(:) = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
-            sknat_hcl_hocl  = sknat_hcl_hocl / minconc
+            sknat_hcl_hocl  = 0.0d0
           elsewhere
             sknat_hcl_hocl  = sknat_hcl_hocl / hcl
           end where
@@ -2848,7 +2848,7 @@
           sknat_hcl_brono2(:) = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
-            sknat_hcl_brono2  = sknat_hcl_brono2 / minconc
+            sknat_hcl_brono2  = 0.0d0
           elsewhere
             sknat_hcl_brono2  = sknat_hcl_brono2 / hcl
           end where
@@ -2889,7 +2889,7 @@
           sknat_hcl_hobr(:) = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
-            sknat_hcl_hobr  = sknat_hcl_hobr / minconc
+            sknat_hcl_hobr  = 0.0d0
           elsewhere
             sknat_hcl_hobr  = sknat_hcl_hobr / hcl
           end where
@@ -3000,7 +3000,7 @@
           skice_hcl_clono2(:)  = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
-            skice_hcl_clono2   = skice_hcl_clono2 / minconc
+            skice_hcl_clono2   = 0.0d0
           elsewhere
             skice_hcl_clono2   = skice_hcl_clono2 / hcl
           end where
@@ -3043,7 +3043,7 @@
           skice_hcl_hocl(:)  = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
-            skice_hcl_hocl   = skice_hcl_hocl / minconc
+            skice_hcl_hocl   = 0.0d0
           elsewhere
             skice_hcl_hocl   = skice_hcl_hocl / hcl
           end where
@@ -3087,7 +3087,7 @@
           skice_hcl_brono2(:)  = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
-            skice_hcl_brono2   = skice_hcl_brono2 / minconc
+            skice_hcl_brono2   = 0.0d0
           elsewhere
             skice_hcl_brono2   = skice_hcl_brono2 / hcl
           end where
@@ -3129,7 +3129,7 @@
           skice_hcl_hobr(:)  = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
-            skice_hcl_hobr   = skice_hcl_hobr / minconc
+            skice_hcl_hobr   = 0.0d0
           elsewhere
             skice_hcl_hobr   = skice_hcl_hobr / hcl
           end where

--- a/GMI_GridComp/GmiChemistry/include/smv2chem_par.h
+++ b/GMI_GridComp/GmiChemistry/include/smv2chem_par.h
@@ -136,7 +136,7 @@
 !     --------------------------------
 
       real*8, parameter ::  &
-     &  ERRMAXIN  = 1.0d-03,     & ! relative error tolerance
+     &  ERRMAXIN  = 1.0d-06,     & ! relative error tolerance  previously 1d-3
      &  YLOWIN    = 1.0d+04,     & ! absolute error tolerance
      &  YHIIN     = 1.0d+06
 


### PR DESCRIPTION
Set a tighter error tolerance for the solver.  Also set reaction rates to zero, for ICE and NAT and STS reactions, when HCl < min-concentration (this prevents some HCl blow-ups).
These changes were adopted toward the end of Benchmark G.