### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/validate_yaml_files.yml
+++ b/.github/workflows/validate_yaml_files.yml
@@ -15,7 +15,7 @@ jobs:
   validate-YAML:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.2.0
+      - uses: actions/checkout@v4
       - id: yaml-lint
         name: yaml-lint
         uses: ibiqlik/action-yamllint@v3
@@ -24,7 +24,7 @@ jobs:
           format: colored
           config_file: .yamllint.yml
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: yamllint-logfile


### PR DESCRIPTION
Soon, GitHub will deprecate the upload-artifacts v3 action:

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

This PR updates the action to the latest version, v4.

It also updates the checkout action to the latest version, v4, as well.