### PR TITLE
add features from Hunga work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 ### Added
+
+- Added features required for the 2024 Hunga experiments, including treatment of SO4v, lbssad_opt 5 (for CARMA), and using sulfate surface area density and effective radius from the AERO state
+
 ### Changed
 
 - Update GitHub actions to use v4

--- a/GMI_GridComp/GMI_GridCompMod.F90
+++ b/GMI_GridComp/GMI_GridCompMod.F90
@@ -156,6 +156,8 @@
 
       CALL GmiEmiss_initSurfEmissBundle    (gcGMI%gcEmiss,     bgg,               expChem,                             __RC__)
 
+      gcGMI%gcThermalRC%so4v_saexist = gcGMI%gcPhot%so4v_saexist
+
       RETURN
 
       END SUBROUTINE GMI_GridCompInitialize
@@ -301,7 +303,7 @@
 
         CALL GmiPhotolysis_GridCompRun(gcGMI%gcPhot,      bgg, bxx, impChem, expChem, nymd, nhms, cdt, __RC__)
 
-        CALL GmiThermalRC_GridCompRun (gcGMI%gcThermalRC, bgg, bxx, impChem, expChem, nymd, nhms, cdt, __RC__)
+        CALL GmiThermalRC_GridCompRun (gcGMI%gcThermalRC, bgg, bxx, impChem, expChem, nymd, nhms, cdt, gcGMI%gcSAD,  __RC__)
 
         CALL GmiChemistry_GridCompRun (gcGMI%gcChem,      bgg, bxx, impChem, expChem, nymd, nhms, cdt, __RC__)
 
@@ -387,7 +389,7 @@
 
       CALL GmiForcingBC_GridCompRun (gcGMI%gcFBC,       bgg, bxx, impChem, expChem, nymd, nhms, cdt,                    __RC__)
 
-      CALL GmiThermalRC_GridCompRun (gcGMI%gcThermalRC, bgg, bxx, impChem, expChem, nymd, nhms, cdt,                    __RC__)
+      CALL GmiThermalRC_GridCompRun (gcGMI%gcThermalRC, bgg, bxx, impChem, expChem, nymd, nhms, cdt, gcGMI%gcSAD,       __RC__)
 
       CALL GmiChemistry_GridCompRun (gcGMI%gcChem,      bgg, bxx, impChem, expChem, nymd, nhms, cdt,                    __RC__)
 

--- a/GMI_GridComp/GmiChem_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiChem_GridCompClassMod.F90
@@ -945,8 +945,8 @@ CONTAINS
                  gmiQQK, gmiQJ, gmiQQJ, surfEmissForChem, self%pr_diag,        &
                  self%do_ftiming, self%do_qqjk_inchem, self%pr_qqjk,           &
                  self%do_semiss_inchem, self%pr_smv2, self%pr_nc_period,       &
-                 rootProc, self%metdata_name_org,             &
-                 self%metdata_name_model, tdt)
+                 i1, i2, j1, j2, 1, km,                                        &
+                 rootProc, self%metdata_name_org, self%metdata_name_model, tdt)
 
 ! Return species concentrations to the chemistry bundle
 ! -----------------------------------------------------

--- a/GMI_GridComp/GmiChemistry/AerosolDust/GmiAerDustODSA_mod.F90
+++ b/GMI_GridComp/GmiChemistry/AerosolDust/GmiAerDustODSA_mod.F90
@@ -16,18 +16,22 @@
 ! !INTERFACE:
 !
       subroutine Aero_OptDep_SurfArea(gridBoxHeight, concentration, tropp, pres3c, &
-     &    optDepth, eRadius, tArea, Odaer, relativeHumidity, dAersl, wAersl, &
-     &    raa_b, qaa_b, do_synoz, isynoz_num, synoz_threshold, AerDust_Effect_opt, &
-     &    i1, i2, ju1, j2, k1, k2, ilo, ihi, julo, jhi, num_species, num_AerDust)
+          optDepth, eRadius, tArea, Odaer, relativeHumidity, dAersl, wAersl,       &
+          raa_b, qaa_b, do_synoz, isynoz_num, synoz_threshold, AerDust_Effect_opt, &
+          i1, i2, ju1, j2, k1, k2, ilo, ihi, julo, jhi, num_species, num_AerDust,  &
+          so4v_nden, so4v_sa, so4v_sareff, so4v_saexist)
 !
 ! !USES:
       use GmiArrayBundlePointer_mod, only : t_GmiArrayBundle
+      use MAPL
 !
       implicit none
 
 #     include "gmi_phys_constants.h"
 #     include "setkin_par.h"
 #     include "gmi_AerDust_const.h"
+#     include "gmi_sad_constants.h"
+
 !
 !... INPUT PARAMETERS:
   integer, intent(in) :: i1, i2, ju1, j2, k1, k2
@@ -48,6 +52,11 @@
   REAL*8, INTENT(IN) :: pres3c(i1:i2, ju1:j2, k1:k2) !Layer mean pressure (hPa)
   REAL*8, intent(in) :: dAersl  (i1:i2, ju1:j2, k1:k2, 2)
   REAL*8, intent(in) :: wAersl  (i1:i2, ju1:j2, k1:k2, NSADaer )
+!... SO4 Volc
+  REAL*8, intent(in) :: so4v_nden (i1:i2, ju1:j2, k1:k2 )
+  REAL*8, intent(in) :: so4v_sa   (i1:i2, ju1:j2, k1:k2 )
+  REAL*8, intent(in) :: so4v_sareff
+  logical,intent(in) :: so4v_saexist
 !... OUTPUT PARAMETERS:
   REAL*8, intent(InOut) :: optDepth(i1:i2, ju1:j2, k1:k2, num_AerDust)
   REAL*8, intent(out) :: eRadius (i1:i2, ju1:j2, k1:k2, NSADdust+NSADaer)
@@ -95,10 +104,18 @@
 
 !   Index to aerosol types in jv_spec.dat
 !   The following are ordered according to the mass densities below
-      INTEGER, SAVE  :: IND(NSADaer) = (/22, 29, 36, 43, 50/)
+      INTEGER, SAVE  :: IND(NSADaer) = (/22, 29, 36, 43, 50, 22/)  !! NOTE: the last (6th) entry is volc SO4
+                                                                   !! and conditionals below check for
+                                                                   !! (n == NSADaer)  -> search for SPECIAL_vSO4
+                                                                   !! if you add entries to the IND vector
 
       INTEGER        :: I, J, R, L, N, IRH, IRHN, IU_cross
       LOGICAL        :: do_calc
+!
+!... Reff growth factor and Qext wrt RH (from FastJX table for Trop sulfate)
+!...  table had: [ 0.159, 0.217, 0.241, 0.260, 0.297, 0.347, 0.498 ]
+      REAL*8,SAVE  :: rhGrthFac(NRH_b)=(/1.0,1.3647798,1.5157233,1.6352202,1.8679246,2.1823900,3.1320755/)
+      REAL*8,SAVE  :: estQdelta(NRH_b)=(/1.0,1.4311564,1.6511167,1.8379983,2.2247667,2.7390444,4.2143059/)
 !
 ! !REVISION HISTORY:
 !   February2005, Jules Kouatchou (Jules.Kouatchou.1@gsfc.nasa.gov)
@@ -115,8 +132,9 @@
       MSDENS(3) = 1800.0    !OC
       MSDENS(4) = 2200.0    !SS (accum)
       MSDENS(5) = 2200.0    !SS (coarse)
+      MSDENS(6) = 1700.0    !SO4 volc
 
-      ! Loop over types of aerosol
+!... Loop over types of hydrophilic aerosols - except Volc SO4
       DO N = 1, NSADaer
 
          ! Zero array
@@ -152,13 +170,21 @@
          DO R = 1, NRH_b
 
             ! Wet radius in "jv_spec.dat"
-            RW(R) = raa_b(4,IND(N)+R-1)
+            if(N.eq.NSADaer) then         !!  SPECIAL_vSO4
+              RW(R) = so4v_sareff * rhGrthFac(R)
+            else
+              RW(R) = raa_b(4,IND(N)+R-1)
+            endif
 
             ! Wet frac of aerosol
             FWET  = (RW(R)**3 - RW(1)**3) / RW(R)**3
 
             ! Extinction efficiency Q for each RH bin
-            QW(R) = qaa_b(4,IND(N)+R-1)*FWET + qaa_b(4,IND(N))*(1.d0-FWET)
+            if(N.eq.NSADaer) then         !!  SPECIAL_vSO4
+              QW(R) = 1.5319 * (estQdelta(R)*FWET + (1.d0-FWET))
+            else
+              QW(R) = qaa_b(4,IND(N)+R-1)*FWET + qaa_b(4,IND(N))*(1.d0-FWET)
+            endif
          ENDDO
 
          ! Loop over SMVGEAR grid boxes
@@ -215,16 +241,18 @@
                   ! #13 Hygroscopic growth of Organic Carbon     [unitless]
                   ! #16 Hygroscopic growth of Sea Salt (accum)   [unitless]
                   ! #19 Hygroscopic growth of Sea Salt (coarse)  [unitless]
+                  ! #22 Hygroscopic growth of Volc SO4           [unitless]
                   !==============================================================
-		  do_calc = .FALSE.
-
-                  IF(do_synoz) THEN
-		   IF(concentration(isynoz_num)%pArray3D(I,J,L) < synoz_threshold) do_calc = .TRUE.
-		  ELSE
-		   IF(pres3c(I,J,L) >= tropp(I,J)) do_calc = .TRUE.
-                  END IF
-
-		  IF(do_calc) optDepth(I,J,L,4+3*N) = optDepth(I,J,L,4+3*N) + SCALEOD(I,J,L,IRH)
+!		  do_calc = .FALSE.
+!
+!                  IF(do_synoz) THEN
+!		   IF(concentration(isynoz_num)%pArray3D(I,J,L) < synoz_threshold) do_calc = .TRUE.
+!		  ELSE
+!		   IF(pres3c(I,J,L) >= tropp(I,J)) do_calc = .TRUE.
+!                  END IF
+!
+!		  IF(do_calc) optDepth(I,J,L,4+3*N) = optDepth(I,J,L,4+3*N) + SCALEOD(I,J,L,IRH)
+		  optDepth(I,J,L,4+3*N) = optDepth(I,J,L,4+3*N) + SCALEOD(I,J,L,IRH)
 
                ENDDO
             ENDDO
@@ -258,25 +286,47 @@
          !       regions (bmy, 2/28/02)
          !==============================================================
 
-         DO R = 1, NRH_b
+         if(N.eq.NSADaer) then         !!  SPECIAL_vSO4
+           DO R = 1, NRH_b
+!... Bin for aerosol type and relative humidity
+              IRHN = ( (N-1) * NRH_b ) + R
 
-            ! Bin for aerosol type and relative humidity
-            IRHN = ( (N-1) * NRH_b ) + R
+              ! Save aerosol optical depth for each combination
+              ! of aerosol type and relative humidity into odAer,
+              ! which will get passed to the FAST-J routines
+              DO L = k1, k2
+                 DO J = ju1, j2
+                    DO I = i1, i2
+                       odAer(I,J,L,IRHN) = SCALEOD(I,J,L,R)  &
+                                  * 0.75d0 * gridBoxHeight(I,J,L)  &
+                                  * so4v_nden(I,J,L) * 0.3537 /  &
+                                  ( MSDENS(N) * so4v_sareff * 1.0D-6 )
+                    ENDDO
+                 ENDDO
+              ENDDO
+           ENDDO
 
-            ! Save aerosol optical depth for each combination
-            ! of aerosol type and relative humidity into odAer,
-            ! which will get passed to the FAST-J routines
-            DO L = k1, k2
-               DO J = ju1, j2
-                  DO I = i1, i2
-                     odAer(I,J,L,IRHN) = SCALEOD(I,J,L,R)  &
-     &                           * 0.75d0 * gridBoxHeight(I,J,L)  &
-     &                           * wAersl(I,J,L,N) * qaa_b(4,IND(N)) /  &
-     &                           ( MSDENS(N) * raa_b(4,IND(N)) * 1.0D-6 )
-                  ENDDO
-               ENDDO
-            ENDDO
-         ENDDO
+         else
+           DO R = 1, NRH_b
+
+              ! Bin for aerosol type and relative humidity
+              IRHN = ( (N-1) * NRH_b ) + R
+
+              ! Save aerosol optical depth for each combination
+              ! of aerosol type and relative humidity into odAer,
+              ! which will get passed to the FAST-J routines
+              DO L = k1, k2
+                 DO J = ju1, j2
+                    DO I = i1, i2
+                       odAer(I,J,L,IRHN) = SCALEOD(I,J,L,R)  &
+                                  * 0.75d0 * gridBoxHeight(I,J,L)  &
+                                  * wAersl(I,J,L,N) * qaa_b(4,IND(N)) /  &
+                                  ( MSDENS(N) * raa_b(4,IND(N)) * 1.0D-6 )
+                    ENDDO
+                 ENDDO
+              ENDDO
+           ENDDO
+         endif
 
          
          !==============================================================
@@ -300,21 +350,31 @@
 
          ! Store aerosol surface areas in tArea, and be sure
          ! to list them following the dust surface areas
-         DO L = k1, k2
-            DO J = ju1, j2
-               DO I = i1, i2
-                  tArea(I,J,L,N+NSADdust) = 3.D0*wAersl(I,J,L,N) *  &
-     &                 SCALEVOL(I,J,L) /  &
-     &                    ( eradius (I,J,L,NSADdust+N) * MSDENS(N) )
-               ENDDO
-            ENDDO
-         ENDDO
+!... do SO4volc
+         if(N.eq.NSADaer) then         !!  SPECIAL_vSO4
+           DO L = k1, k2
+              DO J = ju1, j2
+                 DO I = i1, i2
+                    tArea(I,J,L,N+NSADdust) = so4v_sa(I,J,L)
+                 ENDDO
+              ENDDO
+           ENDDO
+!... the rest of wAersl
+         else
+           DO L = k1, k2
+              DO J = ju1, j2
+                 DO I = i1, i2
+                    tArea(I,J,L,N+NSADdust) = 3.D0*wAersl(I,J,L,N) *  &
+                        SCALEVOL(I,J,L) / ( eradius (I,J,L,NSADdust+N) * MSDENS(N) )
+                 ENDDO
+              ENDDO
+           ENDDO
+         endif
 
-      ENDDO  !Loop over NSADaer
-
+      ENDDO  !Loop over NSADaer - all waersl and Volc SO4
 
       !==============================================================
-      ! Account for hydrophobic aerosols (BC and OC), N=2 and N=3
+      ! Account for hydrophobic aerosols (daersl: BC and OC), N=2 and N=3
       !==============================================================
       DO N = 2, 3
 
@@ -326,9 +386,9 @@
             DO J = ju1, j2
                DO I = i1, i2
                   odAer(I,J,L,IRHN) = odAer(I,J,L,IRHN) +  &
-     &                0.75d0 * gridBoxHeight(I,J,L) *  &
-     &                dAersl(I,J,L,N-1) * qaa_b(4,IND(N))   /  &
-     &                ( MSDENS(N) * raa_b(4,IND(N)) * 1.0D-6 )
+                     0.75d0 * gridBoxHeight(I,J,L) *  &
+                     dAersl(I,J,L,N-1) * qaa_b(4,IND(N))   /  &
+                     ( MSDENS(N) * raa_b(4,IND(N)) * 1.0D-6 )
                ENDDO
             ENDDO
          ENDDO
@@ -360,9 +420,9 @@
                         ! Define a new effective radius that accounts
                         ! for the hydrophobic aerosol
                         eradius(I,J,L,NSADdust+N) = ( eradius(I,J,L,NSADdust+N) *  &
-     &                                   tArea  (I,J,L,NSADdust+N) +  &
-     &                                   REFF * dryArea)          /  &
-     &                                 ( tArea  (I,J,L,NSADdust+N) + dryArea )
+                                        tArea  (I,J,L,NSADdust+N) +  &
+                                        REFF * dryArea)          /  &
+                                      ( tArea  (I,J,L,NSADdust+N) + dryArea )
                      END IF
 
                   END IF
@@ -391,16 +451,18 @@
             odAer(:,:,:,R+2*NRH_b) = 0.d0  !OC
             odAer(:,:,:,R+3*NRH_b) = 0.d0  !SS(accum)
             odAer(:,:,:,R+4*NRH_b) = 0.d0  !SS(coarse)
+            odAer(:,:,:,R+5*NRH_b) = 0.d0  ! volcanic sulfate
          ENDDO
       END IF
 
       ! To turn off heterogeneous chemistry on different aerosols
       IF ((AerDust_Effect_opt == 2) .or. (AerDust_Effect_opt == 3)) THEN
-         tArea(:,:,:,NSADdust+1) = 0.d0  !Sulfate
-         tArea(:,:,:,NSADdust+2) = 0.d0  !BC
-         tArea(:,:,:,NSADdust+3) = 0.d0  !OC
-         tArea(:,:,:,NSADdust+4) = 0.d0  !SS (accum)
-         tArea(:,:,:,NSADdust+5) = 0.d0  !SS (coarse)
+         tArea(:,:,:,NSADdust+ISO4SAD  ) = 0.d0  !Sulfate
+         tArea(:,:,:,NSADdust+IBCSAD   ) = 0.d0  !BC
+         tArea(:,:,:,NSADdust+IOCSAD   ) = 0.d0  !OC
+         tArea(:,:,:,NSADdust+ISSaccSAD) = 0.d0  !SS (accum)
+         tArea(:,:,:,NSADdust+ISScrsSAD) = 0.d0  !SS (coarse)
+         tArea(:,:,:,NSADdust+ISO4vSAD ) = 0.d0  ! volcanic sulfate
       END IF
 
       !==============================================================
@@ -424,6 +486,7 @@
       ! #13 Hygroscopic growth of Organic Carbon     [unitless]
       ! #16 Hygroscopic growth of Sea Salt (accum)   [unitless]
       ! #19 Hygroscopic growth of Sea Salt (coarse)  [unitless]
+      ! #22 Hygroscopic growth of Volc SO4           [unitless]
       !
       ! Computed here:
       ! ---------------------------------
@@ -437,6 +500,8 @@
       ! #17 Sea Salt (accum) Surface Area            [cm2/cm3 ]
       ! #18 Sea Salt (coarse) Opt Depth(400 nm)      [unitless]
       ! #20 Sea Salt (coarse) Surface Area           [cm2/cm3 ]
+      ! #21 Volc Sulfate Optical Depth (400 nm)      [unitless]
+      ! #23 Volc Sulfate Surface Area                [cm2/cm3 ]
       !
       ! NOTE: The cloud optical depths are actually recorded at
       !       1000 nm, but vary little with wavelength.
@@ -457,15 +522,15 @@
 !	   IF(do_synoz) THEN
 !            WHERE (concentration(isynoz_num)%pArray3D(:,:,:) < synoz_threshold)
 !               optDepth(:,:,:,3+3*N) = optDepth(:,:,:,3+3*N) +  &
-!     &                                    odAer(:,:,:,IRHN ) *  &
-!     &                                  qaa_b(2,IND(N)) /qaa_b(4,IND(N))
+!                                          odAer(:,:,:,IRHN ) *  &
+!                                        qaa_b(2,IND(N)) /qaa_b(4,IND(N))
 !            END WHERE
 !	   ELSE
 !            DO L = k1, k2
 !             WHERE(pres3c(:,:,L) >= topp(:,:))
-!              optDepth(:,:,L,3+3*N) = optDepth(:,:,L,3+3*N) +  &
-!     &                                    odAer(:,:,L,IRHN ) *  &
-!     &                                  qaa_b(2,IND(N)) /qaa_b(4,IND(N))
+!               optDepth(:,:,L,3+3*N) = optDepth(:,:,L,3+3*N) +  &
+!                                          odAer(:,:,L,IRHN ) *  &
+!                                        qaa_b(2,IND(N)) /qaa_b(4,IND(N))
 !             END WHERE
 !            END DO
 !	   END IF
@@ -477,13 +542,13 @@
 !	 IF(do_synoz) THEN
 !          WHERE (concentration(isynoz_num)%pArray3D(:,:,:) < synoz_threshold)
 !             optDepth(:,:,:,5+3*N) = optDepth(:,:,:,5+3*N) +  &
-!     &                               tArea(:,:,:,N+NSADdust)
+!                                        tArea(:,:,:,N+NSADdust)
 !          END WHERE
 !         ELSE
 !          DO L = k1, k2
 !           WHERE(pres3c(:,:,L) >= tropp(:,:))
 !             optDepth(:,:,L,5+3*N) = optDepth(:,:,L,5+3*N) +  &
-!     &                               tArea(:,:,L,N+NSADdust)
+!                                        tArea(:,:,L,N+NSADdust)
 !           END WHERE
 !          END DO
 !         END IF
@@ -492,11 +557,11 @@
             ! Index for type of aerosol and RH value
             IRHN = ( (N-1) * NRH_b ) + R
             optDepth(:,:,:,3+3*N) = optDepth(:,:,:,3+3*N) +  &
-     &                                    odAer(:,:,:,IRHN ) *  &
-     &                                  qaa_b(2,IND(N)) /qaa_b(4,IND(N))
+                                       odAer(:,:,:,IRHN ) *  &
+                                       qaa_b(2,IND(N)) /qaa_b(4,IND(N))
          enddo
          optDepth(:,:,:,5+3*N) = optDepth(:,:,:,5+3*N) +  &
-     &                               tArea(:,:,:,N+NSADdust)
+                                    tArea(:,:,:,N+NSADdust)
 
       ENDDO
 
@@ -512,10 +577,10 @@
 !
 ! !INTERFACE:
 !
-      subroutine Dust_OptDep_SurfArea(gridBoxHeight, concentration, &
-     &    tropp, pres3c, optDepth, eradius, tArea, Odmdust, Dust, &
-     &    raa_b, qaa_b, do_synoz, isynoz_num, synoz_threshold, AerDust_Effect_opt, &
-     &    i1, i2, ju1, j2, k1, k2, num_species, num_AerDust)
+      subroutine Dust_OptDep_SurfArea(gridBoxHeight, concentration,               &
+         tropp, pres3c, optDepth, eradius, tArea, Odmdust, Dust,                  &
+         raa_b, qaa_b, do_synoz, isynoz_num, synoz_threshold, AerDust_Effect_opt, &
+         i1, i2, ju1, j2, k1, k2, num_species, num_AerDust)
 !
 ! !USES:
       use GmiArrayBundlePointer_mod, only : t_GmiArrayBundle
@@ -602,8 +667,8 @@
             DO J = ju1, j2
                DO I = i1, i2
                   odmDust(I,J,L,N) = 0.75d0 * gridBoxHeight(I,J,L) *  &
-     &                      dust(I,J,L,N) * qaa_b(4,14+N)     /  &
-     &                     ( MSDENS(N) * raa_b(4,14+N) * 1.0D-6 )
+                           dust(I,J,L,N) * qaa_b(4,14+N)     /        &
+                          ( MSDENS(N) * raa_b(4,14+N) * 1.0D-6 )
                ENDDO
             ENDDO
          ENDDO
@@ -632,13 +697,10 @@
                   eradius(I,J,L,N) = raa_b(4,14+N) * 1.0D-4
 
                   tArea(I,J,L,N)   = 3.D0 / eradius(I,J,L,N) *  &
-     &                      dust(I,J,L,N) / MSDENS(N)
+                            dust(I,J,L,N) / MSDENS(N)
                ENDDO
             ENDDO
          ENDDO
-!
-!         print '(''sdsFJ: '',4e12.4)', MSDENS(N), raa_b(4,14+N)*1.0D-4, maxval(DUST(:,:,:,N)), maxval(TAREA(:,:,:,N))
-!
       ENDDO
 
       !=================================================================
@@ -682,7 +744,7 @@
 ! optDepth tracer #4: Dust optical depths
 !--------------------------------------
              optDepth(:,:,:,4) = optDepth(:,:,:,4) +  &
-     &             (odmDust(:,:,:,N) * qaa_b(2,14+N) / qaa_b(4,14+N))
+                  (odmDust(:,:,:,N) * qaa_b(2,14+N) / qaa_b(4,14+N))
 !--------------------------------------
 ! optDepth tracer #5: Dust surface areas
 !--------------------------------------

--- a/GMI_GridComp/GmiChemistry/GmiPhotolysisRateConstants_mod.F90
+++ b/GMI_GridComp/GmiChemistry/GmiPhotolysisRateConstants_mod.F90
@@ -67,22 +67,24 @@
 ! !INTERFACE:
 !
 
-      subroutine calcPhotolysisRateConstants( JXbundle, tropp,     &
-     &               pr_qj_o3_o1d,  pr_qj_opt_depth,                           &
-     &               pctm2, mass3, pres3e, pres3c, temp3, concentration,       &
-     &               solarZenithAngle, mcor, surf_alb_uv,                      &
-     &               fracCloudCover, tau_cloud, tau_clw, tau_cli,              &
-     &               totalCloudFraction, qi, ql, ri, rl,                       &
-!    &               cnv_frc, frland,                                          &
-     &               overheadO3col, qjgmi, gridBoxHeight, OptDepth,            &
-     &               Eradius, Tarea, Odaer, relativeHumidity, Odmdust, Dust,   &
-     &               Waersl, Daersl, humidity, num_AerDust, phot_opt,          &
-     &               fastj_opt, fastj_offset_sec, do_clear_sky,                &
-     &               do_AerDust_Calc, do_ozone_inFastJX, do_synoz, qj_timpyr,  &
-     &               io3_num, ih2o_num, isynoz_num, chem_mask_khi, nymd, nhms, &
-     &               pr_diag, loc_proc, synoz_threshold, AerDust_Effect_opt,   &
-     &               num_species, num_qjs, num_qjo, ilo, ihi, julo, jhi, &
-     &               i1, i2, ju1, j2, k1, k2, jNOindex, jNOamp, cldflag)
+      subroutine calcPhotolysisRateConstants( JXbundle, tropp,              &
+                  pr_qj_o3_o1d,  pr_qj_opt_depth,                           &
+                  pctm2, mass3, pres3e, pres3c, temp3, concentration,       &
+                  solarZenithAngle, mcor, surf_alb_uv,                      &
+                  fracCloudCover, tau_cloud, tau_clw, tau_cli,              &
+                  totalCloudFraction, qi, ql, ri, rl,                       &
+!                 cnv_frc, frland,                                          &
+                  overheadO3col, qjgmi, gridBoxHeight, OptDepth,            &
+                  Eradius, Tarea, Odaer, relativeHumidity, Odmdust, Dust,   &
+                  Waersl, Daersl, humidity, num_AerDust, phot_opt,          &
+                  fastj_opt, fastj_offset_sec, do_clear_sky,                &
+                  do_AerDust_Calc, do_ozone_inFastJX, do_synoz, qj_timpyr,  &
+                  io3_num, ih2o_num, isynoz_num, chem_mask_khi, nymd, nhms, &
+                  pr_diag, loc_proc, synoz_threshold, AerDust_Effect_opt, num_species, &
+                  so4v_nden, so4v_sa, so4v_sareff, so4v_saexist,            &
+                  num_qjs, num_qjo, ilo, ihi, julo, jhi,                    &
+                  i1, i2, ju1, j2, k1, k2, jNOindex, jNOamp, cldflag)
+
 !
       implicit none
 !
@@ -140,6 +142,12 @@
       real*8 , intent(in) :: ql                 (i1:i2, ju1:j2, k1:k2) ! in-cloud liquid content
       real*8 , intent(in) :: ri                 (i1:i2, ju1:j2, k1:k2) ! effective radius for ice
       real*8 , intent(in) :: rl                 (i1:i2, ju1:j2, k1:k2) ! effective radius for liquid
+!... SO4 Volc
+      real*8 , intent(in) :: so4v_nden          (i1:i2, ju1:j2, k1:k2) ! SO4 Volc part dens calc'd in G2G
+      real*8 , intent(in) :: so4v_sa            (i1:i2, ju1:j2, k1:k2) ! SO4 Volc Surf Area calc'd in G2G
+      real*8 , intent(in) :: so4v_sareff                               ! SO4 Volc Surf Area Reff calc'd in G2G
+      logical, intent(in) :: so4v_saexist                              ! SO4 Volc Surf Area flag
+!
 ! !INPUT/OUTPUT PARAMETERS:
       real*8 , intent(inOut) :: OptDepth(i1:i2, ju1:j2, k1:k2, num_AerDust)
       real*8 , intent(inOut) :: ERADIUS (i1:i2, ju1:j2, k1:k2, NSADdust+NSADaer)
@@ -218,18 +226,19 @@
 
         ! For aerosol/dust optical depth/surface area calculations
         if (do_AerDust_Calc .and. fastj_opt /= 5) then
-           call Aero_OptDep_SurfArea(gridBoxHeight, concentration, tropp,   &
-     &              pres3c, OptDepth, Eradius, Tarea, Odaer,                &
-     &              relativeHumidity, Daersl, Waersl, RAA_b, QAA_b,         &
-     &              do_synoz, isynoz_num, synoz_threshold,                  &
-     &              AerDust_Effect_opt, i1, i2, ju1, j2, k1, k2, ilo, ihi,  &
-     &              julo, jhi, num_species, num_AerDust)
+           call Aero_OptDep_SurfArea(gridBoxHeight, concentration, tropp,  &
+                    pres3c, OptDepth, Eradius, Tarea, Odaer,               &
+                    relativeHumidity, Daersl, Waersl, RAA_b, QAA_b,        &
+                    do_synoz, isynoz_num, synoz_threshold,                 &
+                    AerDust_Effect_opt, i1, i2, ju1, j2, k1, k2, ilo, ihi, &
+                    julo, jhi, num_species, num_AerDust,                   &
+                    so4v_nden, so4v_sa, so4v_sareff, so4v_saexist)
 
-           call Dust_OptDep_SurfArea(gridBoxHeight, concentration, tropp,   &
-     &              pres3c, OptDepth, Eradius, Tarea, Odmdust, Dust, RAA_b, &
-     &              QAA_b, do_synoz, isynoz_num, synoz_threshold,           &
-     &              AerDust_Effect_opt, i1, i2, ju1, j2, k1, k2,            &
-     &              num_species, num_AerDust)
+           call Dust_OptDep_SurfArea(gridBoxHeight, concentration, tropp,  &
+                   pres3c, OptDepth, Eradius, Tarea, Odmdust, Dust, RAA_b, &
+                   QAA_b, do_synoz, isynoz_num, synoz_threshold,           &
+                   AerDust_Effect_opt, i1, i2, ju1, j2, k1, k2,            &
+                   num_species, num_AerDust)
         end if
 !
         if (pr_qj_opt_depth) qjgmi(num_qjo)%pArray3D(:,:,:) = tau_cloud(:,:,:)
@@ -249,11 +258,12 @@
             sza_ij    = solarZenithAngle(il,ij)
             kel_ij(:) = temp3(il,ij,:)
             gridBoxHeight_ij(:) = gridBoxHeight(il,ij,:)
-!... NEED TO SET PROPERLY
+!... NEED TO SET PROPERLY FOR CLOUDJ
             lat_ij    = 0.
 !
-!... for CloudJ aerosol OD calc input
+!... if we are doing aerosol effects on photolysis
             if (do_AerDust_calc) then
+!... for CloudJ aerosol OD calc input
                if (fastj_opt .eq. 5) then 
 !... preprocess for CloudJ AOD calc
 !... hydrophobic BC aerosols
@@ -273,6 +283,7 @@
                  ODAER_ij  (:,:) = ODAER  (il,ij,:,:)
                  ODMDUST_ij(:,:) = ODMDUST(il,ij,:,:)
                endif
+!... if we are NOT doing aerosol effects on photolysis zero out aerosols
             else
               ODAER_ij  (:,:) = 0.0d0
               ODMDUST_ij(:,:) = 0.0d0
@@ -352,7 +363,7 @@
                enddo
 !... wAersl and dAersl aerosol diagnostics
                do N = 1, NSADaer
-!... hydrophilic hygroscopic growth diagnostic  - optDepth(7,10,13,16,19)
+!... hydrophilic hygroscopic growth diagnostic  - optDepth(7,10,13,16,19,22)
                  optDepth(il,ij,:,4+3*N) = optDepth(il,ij,:,4+3*N) + HYGRO_ij(:,N)
                enddo
 !... hydrophilic surface areas diagnostic - optDepth(8,11,14,17,20)

--- a/GMI_GridComp/GmiChemistry/GmiSolverInterface_mod.F90
+++ b/GMI_GridComp/GmiChemistry/GmiSolverInterface_mod.F90
@@ -18,6 +18,7 @@
 ! !PUBLIC MEMBER FUNCTIONS:
       public  :: Update_Smv2chem
 !
+#     include "setkin_par.h"
 #     include "GmiParameters.h"
 #     include "gmi_phys_constants.h"
 #     include "gmi_time_constants.h"
@@ -160,20 +161,20 @@
         end where
       END IF
 
-       allocate(speciesConc(i1:i2, ju1:j2, k1:k2, num_species))
-       do ic = 1, num_species
-          speciesConc(:,:,:,ic) = concentration(ic)%pArray3D(:,:,:)
-       end do
+      allocate(speciesConc(i1:i2, ju1:j2, k1:k2, num_species))
+      do ic = 1, num_species
+         speciesConc(:,:,:,ic) = concentration(ic)%pArray3D(:,:,:)
+      end do
 
-       allocate(loc_qjgmi(i1:i2, ju1:j2, k1:k2, num_qjo))
-       do ic = 1, num_qjo
-          loc_qjgmi(:,:,:,ic) = qjgmi(ic)%pArray3D(:,:,:)
-       end do
+      allocate(loc_qjgmi(i1:i2, ju1:j2, k1:k2, num_qjo))
+      do ic = 1, num_qjo
+         loc_qjgmi(:,:,:,ic) = qjgmi(ic)%pArray3D(:,:,:)
+      end do
 
-       allocate(loc_qkgmi(i1:i2, ju1:j2, k1:k2, num_qks))
-       do ic = 1, num_qks
-          loc_qkgmi(:,:,:,ic) = qkgmi(ic)%pArray3D(:,:,:)
-       end do
+      allocate(loc_qkgmi(i1:i2, ju1:j2, k1:k2, num_qks))
+      do ic = 1, num_qks
+         loc_qkgmi(:,:,:,ic) = qkgmi(ic)%pArray3D(:,:,:)
+      end do
 
 !     IF(rootProc) PRINT *,"Calling Do_Smv2_Solver with do_semiss_inchem=",do_semiss_inchem
 !     ===================

--- a/GMI_GridComp/GmiChemistry/GmiUpdateChemistry_mod.F90
+++ b/GMI_GridComp/GmiChemistry/GmiUpdateChemistry_mod.F90
@@ -19,6 +19,7 @@
 ! !PUBLIC MEMBER FUNCTIONS:
       public  :: updateChemistry
 !
+#     include "setkin_par.h"
 #     include "GmiParameters.h"
 #     include "gmi_phys_constants.h"
 #     include "gmi_time_constants.h"
@@ -55,7 +56,6 @@
 !
       implicit none
 
-#     include "setkin_par.h"
 #     include "gmi_AerDust_const.h"
 !
 ! !INPUT PARAMETERS:

--- a/GMI_GridComp/GmiChemistry/GmiUpdateForcingBC_mod.F90
+++ b/GMI_GridComp/GmiChemistry/GmiUpdateForcingBC_mod.F90
@@ -18,6 +18,7 @@
 ! !PUBLIC MEMBER FUNCTIONS:
       public  :: updateForcingBC
 !     
+#     include "setkin_par.h"
 #     include "GmiParameters.h"
 #     include "gmi_phys_constants.h"
 #     include "gmi_time_constants.h"

--- a/GMI_GridComp/GmiChemistry/GmiUpdateSAD_mod.F90
+++ b/GMI_GridComp/GmiChemistry/GmiUpdateSAD_mod.F90
@@ -17,6 +17,7 @@
 !
       implicit none
 !
+#     include "setkin_par.h"
 #     include "GmiParameters.h"
 #     include "gmi_phys_constants.h"
 #     include "gmi_sad_constants.h"

--- a/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_GridComp.rc
+++ b/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_GridComp.rc
@@ -203,6 +203,8 @@ emissionSpeciesLayers::
 
 emissionPointFilenames::
 SO2:volcano:ExtData/chemistry/CARN/v202106/sfc/so2_volcanic_emissions_Carns.%y4%m2%d2.rc
+#SO2:SO2:/discover/nobackup/pcolarco/fvInput/pointwise_sources/hunga_tonga/so2_volcanic_emissions_TongaMIP_exp2.GMI.%y4%m2%d2.rc
+#H2O:H2O:/discover/nobackup/pcolarco/fvInput/pointwise_sources/hunga_tonga/so2_volcanic_emissions_TongaMIP_exp2.GMI.%y4%m2%d2.rc
 ::
 # NOTE: Units for the volcano point source files: kg(S)/s
 #       Units that GMI wants                    : kg(SO2)/s
@@ -295,12 +297,19 @@ forc_bc_kmax: 2
 #forc_bc_infile_name:              ExtData/g5chem/x/GMI/RCP6.0_5BrWMO2014_ch4latvar_1950_2100.asc
 #forc_bc_infile_name:              ExtData/g5chem/x/GMI/RCP6.0_5BrWMO2018_ch4latvar_1950_2100.asc
 #forc_bc_infile_name:              ExtData/g5chem/x/GMI/ccmiRefD1_GMIbc_1950_2018.asc
+#forc_bc_infile_name:  /discover/nobackup/projects/gmao/ccmdev/mmanyin/bench/GOLF/INPUT/BC/ccmiRefD1_GMIbc_plusHFC_extra5Br_1950_2018.asc
 #forc_bc_infile_name:  /discover/nobackup/projects/gmao/ccmdev/mmanyin/bench/bench_10-26-0_gmi_free_c360_72lev/INPUT/BC/ccmiRefD1_GMIbc_plusHFC_1950_2018.asc
+
+#forc_bc_infile_name:  /discover/nobackup/projects/gmi/gmidata2/users/steenrod/input/source_gas/ccmiRefD2_GMIbc_1950_2100_24species_no5Br_wHFCs.asc
+# CFC11 CFC12 CFC113 CFC114 CFC115 CCl4 CH3CCl3 HCFC22 HCFC141b HCFC142b
+# CF2ClBr CF2Br2 CF3Br H2402 CH3Br CH3Cl CH4 N2O HFC23 HFC32
+# HFC125 HFC134a HFC143a HFC152a
+
 forc_bc_infile_name:  /discover/nobackup/projects/gmao/ccmdev/mmanyin/bench/GOLF/INPUT/BC/ccmiRefD1_GMIbc_plusHFC_no5Br_1950_2018.asc
 
 #alternative /discover/nobackup/projects/gmi/gmidata2/users/steenrod/input/source_gas/RCP6.0_WMO2018_QingHFCs_ch4latvarGMDscl_1950_2022Hindcast.asc
 
-forcedBcSpeciesNames:: 
+forcedBcSpeciesNames::
 #CFC11
 #CFC12
 #CFC113
@@ -381,9 +390,10 @@ sad_opt: 2
 #     ----------------------------------------------
 #     lbssad_opt
 #       1:  set all lbssad values to lbssad_init_val
-#       2:  OBSOLETE - read in lbssad 3d fields
-#       3:  OBSOLETE - read in lbssad zonal average fields
-#       4:  lbssad provided by AGCM, current month only.
+#       2: (OBSOLETE)  read in lbssad 3d fields
+#       3: (OBSOLETE)  read in lbssad zonal average fields
+#       4:  lbssad provided by AGCM (ExtData)
+#       5:  lbssad provided by CARMA SO4SAREA
 #     ----------------------------------------------
 #     (as listed in GmiSAD_GridCompClassMod.F90)
 

--- a/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_Registry.rc
+++ b/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_Registry.rc
@@ -252,6 +252,9 @@
   SSCOD   	    | 1              | xyz | C |    |	|   |	  | coarse_sea_salt_optical_depth_(400_nm)
   SSCHYGRO   	    | 1              | xyz | C |    |	|   |	  | hygroscopic_growth_of_coarse_sea_salt
   SSCSA   	    | cm+2 cm-3      | xyz | C |    |	|   |	  | coarse_sea_salt_surface_area
+  SO4vOD   	    | 1              | xyz | C |    |	|   |	  | volc_sulfate_optical_depth_(400_nm)
+  SO4vHYGRO   	    | 1              | xyz | C |    |	|   |	  | hygroscopic_growth_of_volc_sulfate
+  SO4vSA   	    | cm+2 cm-3      | xyz | C |    |	|   |	  | volc_sulfate_surface_area
   O3    	    | kg kg-1        | xyz | C |    |	|   |	  | ozone_mass_mixing_ratio
   O3PPMV    	    | ppmv           | xyz | C |    |	|   |	  | ozone_mass_mixing_ratio_in_ppm
   OX_TEND    	    | kg kg-1 s-1    | xyz | C |    |	|   |	  | tendency_of_odd_oxygen_mixing_ratio_due_to_chemistry
@@ -265,6 +268,8 @@
   NATSAD  	    | cm+2 cm-3      | xyz | C |    |	|   |	  | NAT_surface_area_density
   ICESAD  	    | cm+2 cm-3      | xyz | C |    |	|   |	  | ice_surface_area_density
   LBSSAD  	    | cm+2 cm-3      | xyz | C |    |	|   |	  | LBS_surface_area_density
+  STSSAD            | cm+2 cm-3      | xyz | C |    |   |   |     | STS_surface_area_density
+  SOOTSAD           | cm+2 cm-3      | xyz | C |    |   |   |     | Soot_surface_area_density
   AIRMASS           | kg m-2         | xyz | C |    |   |   |     | mass_of_air_in_layer
   OCS_JRATE         | s-1            | xyz | C |    |   |   |     | Jrate_for_OCS    
 # ------------------|----------------|-----|---|----|---|---|-----|---------------------------------

--- a/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/setkin_kcalc.F90
+++ b/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/setkin_kcalc.F90
@@ -26,8 +26,8 @@
 !
 !=======================================================================
       subroutine kcalc( npres0,sadcol,sadcol2,pressure,ptrop,cPBLcol, &
-     &  temperature,lwc,adcol,specarr,rcarr,radA,FRH)
-
+     &  temperature,fcld,lwc,adcol,specarr,rcarr,radA,FRH)
+!
       implicit none
 
 #     include "gmi_phys_constants.h"
@@ -42,6 +42,7 @@
       REAL*8,  INTENT (IN)  :: ptrop
 
       REAL*8,  INTENT (IN)  :: adcol       (       npres0)
+      REAL*8,  INTENT (IN)  :: fcld        (       npres0)
       REAL*8,  INTENT (IN)  :: lwc         (       npres0)
       REAL*8,  INTENT (IN)  :: pressure    (       npres0)
       REAL*8,  INTENT (IN)  :: temperature (       npres0)
@@ -71,7 +72,11 @@
      & ,sad_sts  (npres0)
 
       real*8 mw(NSP)
-
+!
+      real*8, DIMENSION (npres0) :: wt_h2so4, g_clono2, g_clono2_hcl, g_clono2_h2o, g_hocl
+!... effective radii of stratospheric aerosols
+      real*8 reff_lbs, reff_sts, reff_nat, reff_ice, reff_soot
+!
       mw(:) = mw_data(:)
 
       naltmax     = npres0
@@ -88,7 +93,13 @@
       nitrogen(:) = adcol(:) * MXRN2
       oxygen(:)   = adcol(:) * MXRO2
       water(:)    = specarr(44 ,:)
-
+!... * 0.0d0
+      reff_lbs  = 0.221d-4
+      reff_sts  = 0.221d-4
+      reff_nat  = 0.221d-4
+      reff_ice  = 0.221d-4
+      reff_soot = 0.221d-4
+!
       sad_lbs(:)  = sadcol(1, :)
       sad_sts(:)  = sadcol(2, :)
       sad_nat(:)  = sadcol(3, :)
@@ -96,6 +107,9 @@
 !.old      sad_soot(:) = sadcol(5, :)
 !... Use GOCART soot (BC+OC) for this reaction
       sad_soot(:) = sadcol2(NSADdust+2,:)+sadcol2(NSADdust+3,:)
+!
+!... since STS is not calculated at present put Volc SO4 in there
+
 !
 !
 !....          Start thermal rate constants
@@ -2175,7 +2189,7 @@
 !=======================================================================
 !     N2O5 + stratospheric sulfate aerosol = 2 HNO3
 !=======================================================================
-!           
+!
 !.sds..!.... First order reaction rate constant
 !.sds..!.... PSC 3/30/99
 !.sds..      gamma     = 0.10d0
@@ -2465,6 +2479,7 @@
           where( hcl > minconc )
             sksts_clono2_hcl = 0.25d0 * gprob_hcl * avgvel * sad / hcl
           elsewhere
+!.old            sksts_clono2_hcl = 0.25d0 * gprob_hcl * avgvel * sad
             sksts_clono2_hcl = 0.0d0
           end where
 !
@@ -2621,6 +2636,7 @@
           where( hcl > minconc )
             sksts_hocl_hcl = 0.25d0 * gprob_tot * avgvel * sad / hcl
           elsewhere
+!.old            sksts_hocl_hcl = 0.25d0 * gprob_tot * avgvel * sad
             sksts_hocl_hcl = 0.0d0
           end where
 !
@@ -2735,6 +2751,7 @@
           where( hcl > minconc )
             sksts_hobr_hcl = 0.25d0 * gprob_tot * avgvel * sad / hcl
          elsewhere
+!.old            sksts_hobr_hcl = 0.25d0 * gprob_tot * avgvel * sad
             sksts_hobr_hcl = 0.0d0
          end where
 !
@@ -2846,6 +2863,7 @@
           sknat_hcl_clono2(:) = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
+!.old            sknat_hcl_clono2  = sknat_hcl_clono2 / minconc
             sknat_hcl_clono2  = 0.0d0
           elsewhere
             sknat_hcl_clono2  = sknat_hcl_clono2 / hcl
@@ -2886,6 +2904,7 @@
           sknat_hcl_hocl(:) = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
+!.old            sknat_hcl_hocl  = sknat_hcl_hocl / minconc
             sknat_hcl_hocl  = 0.0d0
           elsewhere
             sknat_hcl_hocl  = sknat_hcl_hocl / hcl
@@ -2926,6 +2945,7 @@
           sknat_hcl_brono2(:) = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
+!.old            sknat_hcl_brono2  = sknat_hcl_brono2 / minconc
             sknat_hcl_brono2  = 0.0d0
           elsewhere
             sknat_hcl_brono2  = sknat_hcl_brono2 / hcl
@@ -2966,6 +2986,7 @@
           sknat_hcl_hobr(:) = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
+!.old            sknat_hcl_hobr  = sknat_hcl_hobr / minconc
             sknat_hcl_hobr  = 0.0d0
           elsewhere
             sknat_hcl_hobr  = sknat_hcl_hobr / hcl
@@ -3077,6 +3098,7 @@
           skice_hcl_clono2(:)  = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
+!.old            skice_hcl_clono2   = skice_hcl_clono2 / minconc
             skice_hcl_clono2   = 0.0d0
           elsewhere
             skice_hcl_clono2   = skice_hcl_clono2 / hcl
@@ -3119,6 +3141,7 @@
           skice_hcl_hocl(:)  = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
+!.old            skice_hcl_hocl   = skice_hcl_hocl / minconc
             skice_hcl_hocl   = 0.0d0
           elsewhere
             skice_hcl_hocl   = skice_hcl_hocl / hcl
@@ -3162,6 +3185,7 @@
           skice_hcl_brono2(:)  = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
+!.old            skice_hcl_brono2   = skice_hcl_brono2 / minconc
             skice_hcl_brono2   = 0.0d0
           elsewhere
             skice_hcl_brono2   = skice_hcl_brono2 / hcl
@@ -3204,6 +3228,7 @@
           skice_hcl_hobr(:)  = 0.25d0 * gprob * avgvel(:) * sad(:)
 !
           where (hcl < minconc)
+!.old            skice_hcl_hobr   = skice_hcl_hobr / minconc
             skice_hcl_hobr   = 0.0d0
           elsewhere
             skice_hcl_hobr   = skice_hcl_hobr / hcl
@@ -3412,7 +3437,7 @@
 ! use the HO2-only algebraic expression.
 !
 !----------------
-        CASE ( 8, 9, 10, 11, 12)  
+        CASE ( 8, 9, 10, 11, 12, 13)  
 !
 !... Mean molecular speed [cm/s]
           w = 14550.5d0 * sqrt(TEMP/(SQM*SQM))
@@ -3480,7 +3505,10 @@
 !...  which is in the middle of the 0.04-0.1 range recommended
 !...  by Thornton et al. (2008)
 !... 
-          IF ( AEROTYPE == 8 .and. CONTINENTAL_PBL == 1) THEN
+          IF ( AEROTYPE ==  8 .and. CONTINENTAL_PBL == 1) THEN
+            GAMMA = 0.07
+          ENDIF 
+          IF ( AEROTYPE == 13 .and. CONTINENTAL_PBL == 1) THEN
             GAMMA = 0.07
           ENDIF 
 !

--- a/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/setkin_par.h
+++ b/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/setkin_par.h
@@ -50,7 +50,7 @@
 
       parameter (nSAD  =   5)
       parameter (nSADdust =   7)
-      parameter (nSADaer =   5)
+      parameter (nSADaer =   6)
 
 
 !.... Species individual identifications

--- a/GMI_GridComp/GmiChemistry/StratTrop_Orig/GMI_GridComp.rc
+++ b/GMI_GridComp/GmiChemistry/StratTrop_Orig/GMI_GridComp.rc
@@ -189,6 +189,8 @@ emissionSpeciesLayers::
 
 #emissionPointFilenames::
 #SO2:volcano:ExtData/chemistry/CARN/v202106/sfc/so2_volcanic_emissions_Carns.%y4%m2%d2.rc
+##SO2:SO2:/discover/nobackup/pcolarco/fvInput/pointwise_sources/hunga_tonga/so2_volcanic_emissions_TongaMIP_exp2.GMI.%y4%m2%d2.rc
+##H2O:H2O:/discover/nobackup/pcolarco/fvInput/pointwise_sources/hunga_tonga/so2_volcanic_emissions_TongaMIP_exp2.GMI.%y4%m2%d2.rc
 #::
 # NOTE: Units for the volcano point source files: kg(S)/s
 #       Units that GMI wants                    : kg(SO2)/s
@@ -282,11 +284,18 @@ forc_bc_kmax: 2
 #forc_bc_infile_name:              ExtData/g5chem/x/GMI/RCP6.0_5BrWMO2018_ch4latvar_1950_2100.asc
 #forc_bc_infile_name:              ExtData/g5chem/x/GMI/ccmiRefD1_GMIbc_1950_2018.asc
 #forc_bc_infile_name:  /discover/nobackup/projects/gmao/ccmdev/mmanyin/bench/GOLF/INPUT/BC/ccmiRefD1_GMIbc_plusHFC_extra5Br_1950_2018.asc
+#forc_bc_infile_name:  /discover/nobackup/projects/gmao/ccmdev/mmanyin/bench/bench_10-26-0_gmi_free_c360_72lev/INPUT/BC/ccmiRefD1_GMIbc_plusHFC_1950_2018.asc
+
+#forc_bc_infile_name:  /discover/nobackup/projects/gmi/gmidata2/users/steenrod/input/source_gas/ccmiRefD2_GMIbc_1950_2100_24species_no5Br_wHFCs.asc
+# CFC11 CFC12 CFC113 CFC114 CFC115 CCl4 CH3CCl3 HCFC22 HCFC141b HCFC142b
+# CF2ClBr CF2Br2 CF3Br H2402 CH3Br CH3Cl CH4 N2O HFC23 HFC32
+# HFC125 HFC134a HFC143a HFC152a
+
 forc_bc_infile_name:  /discover/nobackup/projects/gmao/ccmdev/mmanyin/bench/GOLF/INPUT/BC/ccmiRefD1_GMIbc_plusHFC_no5Br_1950_2018.asc
 
 #alternative /discover/nobackup/projects/gmi/gmidata2/users/steenrod/input/source_gas/RCP6.0_WMO2018_QingHFCs_ch4latvarGMDscl_1950_2022Hindcast.asc
 
-forcedBcSpeciesNames:: 
+forcedBcSpeciesNames::
 #CFC11
 #CFC12
 #CFC113
@@ -367,9 +376,10 @@ sad_opt: 2
 #     ----------------------------------------------
 #     lbssad_opt
 #       1:  set all lbssad values to lbssad_init_val
-#       2:  OBSOLETE - read in lbssad 3d fields
-#       3:  OBSOLETE - read in lbssad zonal average fields
-#       4:  lbssad provided by AGCM, current month only.
+#       2: (OBSOLETE)  read in lbssad 3d fields
+#       3: (OBSOLETE)  read in lbssad zonal average fields
+#       4:  lbssad provided by AGCM (ExtData)
+#       5:  lbssad provided by CARMA SO4SAREA
 #     ----------------------------------------------
 #     (as listed in GmiSAD_GridCompClassMod.F90)
 

--- a/GMI_GridComp/GmiChemistry/StratTrop_Orig/GMI_Registry.rc
+++ b/GMI_GridComp/GmiChemistry/StratTrop_Orig/GMI_Registry.rc
@@ -230,6 +230,9 @@
   SSCOD   	    | 1              | xyz | C |    |	|   |	  | coarse_sea_salt_optical_depth_(400_nm)
   SSCHYGRO   	    | 1              | xyz | C |    |	|   |	  | hygroscopic_growth_of_coarse_sea_salt
   SSCSA   	    | cm+2 cm-3      | xyz | C |    |	|   |	  | coarse_sea_salt_surface_area
+  SO4vOD   	    | 1              | xyz | C |    |	|   |	  | volc_sulfate_optical_depth_(400_nm)
+  SO4vHYGRO   	    | 1              | xyz | C |    |	|   |	  | hygroscopic_growth_of_volc_sulfate
+  SO4vSA   	    | cm+2 cm-3      | xyz | C |    |	|   |	  | volc_sulfate_surface_area
   O3    	    | kg kg-1        | xyz | C |    |	|   |	  | ozone_mass_mixing_ratio
   O3PPMV    	    | ppmv           | xyz | C |    |	|   |	  | ozone_mass_mixing_ratio_in_ppm
   OX_TEND    	    | kg kg-1 s-1    | xyz | C |    |	|   |	  | tendency_of_odd_oxygen_mixing_ratio_due_to_chemistry
@@ -243,6 +246,8 @@
   NATSAD  	    | cm+2 cm-3      | xyz | C |    |	|   |	  | NAT_surface_area_density
   ICESAD  	    | cm+2 cm-3      | xyz | C |    |	|   |	  | ice_surface_area_density
   LBSSAD  	    | cm+2 cm-3      | xyz | C |    |	|   |	  | LBS_surface_area_density
+  STSSAD            | cm+2 cm-3      | xyz | C |    |   |   |     | STS_surface_area_density
+  SOOTSAD           | cm+2 cm-3      | xyz | C |    |   |   |     | Soot_surface_area_density
   AIRMASS           | kg m-2         | xyz | C |    |   |   |     | mass_of_air_in_layer
   OCS_JRATE         | s-1            | xyz | C |    |   |   |     | Jrate_for_OCS
 # ------------------|----------------|-----|---|----|---|---|-----|---------------------------------

--- a/GMI_GridComp/GmiChemistry/StratTrop_Orig/setkin_par.h
+++ b/GMI_GridComp/GmiChemistry/StratTrop_Orig/setkin_par.h
@@ -50,7 +50,7 @@
 
       parameter (NSAD  =   5)
       parameter (NSADdust =   7)
-      parameter (NSADaer =   5)
+      parameter (NSADaer =   6)
 
 
 !.... Species individual identifications

--- a/GMI_GridComp/GmiChemistry/include/smv2chem_par.h
+++ b/GMI_GridComp/GmiChemistry/include/smv2chem_par.h
@@ -136,7 +136,7 @@
 !     --------------------------------
 
       real*8, parameter ::  &
-     &  ERRMAXIN  = 1.0d-06,     & ! relative error tolerance  previously 1d-3
+     &  ERRMAXIN  = 1.0d-06,     & ! relative error tolerance  previously 1d-3, seems to help w/ HCl blowups and O1D spikes
      &  YLOWIN    = 1.0d+04,     & ! absolute error tolerance
      &  YHIIN     = 1.0d+06
 

--- a/GMI_GridComp/GmiChemistry/ioChemistry/ReadForcedBC_mod.F90
+++ b/GMI_GridComp/GmiChemistry/ioChemistry/ReadForcedBC_mod.F90
@@ -47,6 +47,7 @@
       implicit none
 !
 #     include "gmi_forc_bc.h"
+#     include "setkin_par.h"
 #     include "GmiParameters.h"
 !
 ! !INPUT PARAMETERS:

--- a/GMI_GridComp/GmiChemistry/ioChemistry/ReadSolarCycle_mod.F90
+++ b/GMI_GridComp/GmiChemistry/ioChemistry/ReadSolarCycle_mod.F90
@@ -40,6 +40,7 @@
 !
       implicit none
 !
+#include "setkin_par.h"
 #include "GmiParameters.h"
 #include "parm_MIE_fastJX65.h"
 !

--- a/GMI_GridComp/GmiChemistry/photolysis/CloudJ/CloudJ_mod.F90
+++ b/GMI_GridComp/GmiChemistry/photolysis/CloudJ/CloudJ_mod.F90
@@ -92,13 +92,13 @@
       real, dimension(L_) :: CLDFRW, CLDIWCW, CLDLWCW, CLDREFFI, CLDREFFL
       logical :: oldgmi_aero=.true.
 !
-!. tropSO4, BC, OC, SeaSalt(accum), SeaSalt(coarse)
+!. tropSO4, BC, OC, SeaSalt(accum), SeaSalt(coarse), volcSO4
       integer :: IR, IRH, ioffd, kdry
-      integer, parameter :: idxAtype(NSADaer)=(/-1, -14, -22, -4, -5/), NRH_GMI=(7)
+      integer, parameter :: idxAtype(NSADaer)=(/-1, -14, -22, -4, -5, -2/), NRH_GMI=(7)
 !. old tropSO4, BC, OC, SeaSalt(accum), SeaSalt(coarse) densities
       real, dimension(NSADdust), parameter :: dMSDENS=(/2500.0, 2500.0, 2500.0, 2500.0, 2650.0, 2650.0, 2650.0/)
-      real, dimension(NSADaer), parameter :: wMSDENS=(/1700.0, 1000.0, 1800.0, 2200.0, 2200.0/)
-!      INTEGER, parameter :: IND(NSADaer) = (/22, 29, 36, 43, 50/)
+      real, dimension(NSADaer), parameter :: wMSDENS=(/1700.0, 1000.0, 1800.0, 2200.0, 2200.0, 1700./)
+!      INTEGER, parameter :: IND(NSADaer) = (/22, 29, 36, 43, 50, ??/)
       REAL*8 :: FRAC, REFF, scaleR, scaleQ
 !
 !

--- a/GMI_GridComp/GmiChemistry/photolysis/fast_JX65/fastJX65_mod.F90
+++ b/GMI_GridComp/GmiChemistry/photolysis/fast_JX65/fastJX65_mod.F90
@@ -74,7 +74,6 @@
       real*8, intent(in)  :: ODMDUST_ij(k1:k2,NSADdust)    ! optical depth for mineral dust
       real*8, intent(in)    :: fjx_solar_cycle_param(W_)    ! solar cycle scalings
 !
-!      real*8, optional, intent(in) :: ozone_ij(k1:k2)      ! mixing ratio for ozone
       real*8, intent(in), optional :: ozone_ij(k1:k2)      ! mixing ratio for ozone
 !
 ! !OUTPUT PARAMETERS:

--- a/GMI_GridComp/GmiChemistry/smv2chem/jsparseGMI.F90
+++ b/GMI_GridComp/GmiChemistry/smv2chem/jsparseGMI.F90
@@ -842,7 +842,7 @@
 
       if (ic /= savedVars%nallrat(ncs)) then
         Write (6,810) ic, savedVars%nallrat(ncs)
-        err_msg = ' Problem in Jsparse '
+        err_msg = ' Problem in Jsparse 1 '
         call GmiPrintError (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
       end if
 
@@ -917,7 +917,7 @@
         if ((numgaint(k,ncs) > MAXGL) .or.  &
      &      (numlost (k,ncs) > MAXGL)) then
           Write (6,820) namesp2(j,ncs), numgaint(k,ncs), numlost(k,ncs)
-          err_msg = ' Problem in Jsparse '
+          err_msg = ' Problem in Jsparse 2 '
           call GmiPrintError (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
         end if
 
@@ -927,7 +927,7 @@
      &    (ngnfrac(ncs) > MAXGL)) then
         Write (6,830) MAXGL2, savedVars%nmoth(ncs), MAXGL3, savedVars%nolosp(ncs),  &
      &                MAXGL, ngnfrac(ncs)
-        err_msg = ' Problem in Jsparse '
+        err_msg = ' Problem in Jsparse 3 '
         call GmiPrintError (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
       end if
 
@@ -1170,7 +1170,7 @@
      &                  MXCOUNT4, nprcoun, MXCOUNT4, nfrcoun,  &
      &                  MXCOUNT2, npdcoun
 
-          err_msg = ' Problem in Jsparse '
+          err_msg = ' Problem in Jsparse 4 '
           call GmiPrintError (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
 
         end if

--- a/GMI_GridComp/GmiChemistry/smv2chem/smvgearGMI.F90
+++ b/GMI_GridComp/GmiChemistry/smv2chem/smvgearGMI.F90
@@ -744,10 +744,10 @@
           Write (lunsmv,950) delt, timremain, yfac, savedVars%errmax(ncs)
         end if
 
- 950    format ('Smvgear:  delt      = ', 1pe9.3, /,  &
-     &          '          timremain = ', 1pe9.3, /,  &
-     &          '          yfac      = ', 1pe9.3, /,  &
-     &          '          errmax    = ', 1pe9.3)
+ 950    format ('Smvgear:  delt      = ', 1pe10.3, /,  &
+     &          '          timremain = ', 1pe10.3, /,  &
+     &          '          yfac      = ', 1pe10.3, /,  &
+     &          '          errmax    = ', 1pe10.3)
 
         nylowdec = nylowdec + 1
         yfac     = yfac * 0.01d0

--- a/GMI_GridComp/GmiDeposition/GmiDepositionMethod_mod.F90
+++ b/GMI_GridComp/GmiDeposition/GmiDepositionMethod_mod.F90
@@ -44,6 +44,7 @@
 !
   public  :: t_Deposition
 
+#     include "setkin_par.h"
 #     include "GmiParameters.h"
 #     include "gmi_emiss_constants.h"
 

--- a/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
+++ b/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
@@ -2070,7 +2070,7 @@ CONTAINS
 !!  IF(ASSOCIATED(EM_pointer)) EM_pointer(i1:i2,j1:j2,km:1:-1) = &
 !!                               (AIRDENS(i1:i2,j1:j2,km:1:-1) * gridBoxThickness(i1:i2,j1:j2,1:km)) / MAPL_AIRMW
 
-!! NATSAD and ICESAD
+!! NATSAD, ICESAD, LBSSAD, SOOTSAD and STSSAD (really VOLCSAD for now)
      call ESMF_StateGet (expChem, "gmiSAD", sadBundle, RC=STATUS )
      VERIFY_(STATUS)
 
@@ -2089,6 +2089,18 @@ CONTAINS
      CALL MAPL_GetPointer(expChem, EM_pointer, "LBSSAD", __RC__)
      IF(ASSOCIATED(EM_pointer)) THEN
        CALL obtainTracerFromBundle(sadBundle, ptr3D, ILBSSAD)
+       EM_pointer(i1:i2,j1:j2,1:km) = ptr3D(i1:i2,j1:j2,1:km)
+     END IF
+
+     CALL MAPL_GetPointer(expChem, EM_pointer, "STSSAD", __RC__)
+     IF(ASSOCIATED(EM_pointer)) THEN
+       CALL obtainTracerFromBundle(sadBundle, ptr3D, ISTSSAD)
+       EM_pointer(i1:i2,j1:j2,1:km) = ptr3D(i1:i2,j1:j2,1:km)
+     END IF
+
+     CALL MAPL_GetPointer(expChem, EM_pointer, "SOOTSAD", __RC__)
+     IF(ASSOCIATED(EM_pointer)) THEN
+       CALL obtainTracerFromBundle(sadBundle, ptr3D, ISTSSAD)
        EM_pointer(i1:i2,j1:j2,1:km) = ptr3D(i1:i2,j1:j2,1:km)
      END IF
 

--- a/GMI_GridComp/GmiEmission/GmiEmissionMethod_mod.F90
+++ b/GMI_GridComp/GmiEmission/GmiEmissionMethod_mod.F90
@@ -49,6 +49,7 @@
 ! !PUBLIC MEMBER DATA:
       public  :: t_Emission
 
+# include "setkin_par.h"
 # include "GmiParameters.h"
 # include "gmi_emiss_constants.h"
 # include "gmi_phys_constants.h"

--- a/GMI_GridComp/GmiShared/GmiESMF/GmiESMFrcFileReading_mod.F90
+++ b/GMI_GridComp/GmiShared/GmiESMF/GmiESMFrcFileReading_mod.F90
@@ -30,6 +30,7 @@
         module procedure rcEsmfReadTable2ListWords
       end interface
 
+#     include "setkin_par.h"
 #     include "GmiParameters.h"
 !
 ! !DESCRIPTION:

--- a/GMI_GridComp/GmiShared/GmiESMF/GmiFieldBundleESMF_mod.F90
+++ b/GMI_GridComp/GmiShared/GmiESMF/GmiFieldBundleESMF_mod.F90
@@ -51,6 +51,7 @@
          module procedure obtainTracerFromBundle_ByName2D_r8
       end interface
 
+#     include "setkin_par.h"
 #     include "GmiParameters.h"
 
 ! !DESCRIPTION:
@@ -87,12 +88,18 @@
 !EOP
 !------------------------------------------------------------------------------
 !BOC
-      field = ESMF_FieldCreate(grid=grid, fArrayptr=PTR, &
-              name = fieldName, RC=STATUS )
-      VERIFY_(STATUS)
+      field = ESMF_FieldCreate(grid=grid, fArrayptr=PTR, name=fieldName, __RC__ )
 
-      call MAPL_FieldBundleAdd ( bundle, field, rc=STATUS )
-      VERIFY_(STATUS)
+      call ESMF_AttributeSet(field,name="DIMS",               value=MAPL_DimsHorzVert,    __RC__)
+      call ESMF_AttributeSet(field,name="VLOCATION",          value=MAPL_VLocationCenter, __RC__)
+      call ESMF_AttributeSet(field,name="UNITS",              value="NA",                 __RC__)
+      call ESMF_AttributeSet(field,name="LONG_NAME",          value="NA",                 __RC__)
+      call ESMF_AttributeSet(field,name="FIELD_TYPE",         value=1,                    __RC__)
+      call ESMF_AttributeSet(field,name="REFRESH_INTERVAL",   value=0,                    __RC__)
+      call ESMF_AttributeSet(field,name="AVERAGING_INTERVAL", value=0,                    __RC__)
+
+      call MAPL_FieldBundleAdd ( bundle, field, __RC__ )
+
 
       return
 
@@ -124,12 +131,17 @@
 !EOP
 !------------------------------------------------------------------------------
 !BOC
-      field = ESMF_FieldCreate(grid=grid, fArrayptr=PTR, &
-              name = fieldName, RC=STATUS )
-      VERIFY_(STATUS)
+      field = ESMF_FieldCreate(grid=grid, fArrayptr=PTR, name=fieldName, __RC__ )
 
-      call MAPL_FieldBundleAdd ( bundle, field, rc=STATUS )
-      VERIFY_(STATUS)
+      call ESMF_AttributeSet(field,name="DIMS",               value=MAPL_DimsHorzVert,    __RC__)
+      call ESMF_AttributeSet(field,name="VLOCATION",          value=MAPL_VLocationCenter, __RC__)
+      call ESMF_AttributeSet(field,name="UNITS",              value="NA",                 __RC__)
+      call ESMF_AttributeSet(field,name="LONG_NAME",          value="NA",                 __RC__)
+      call ESMF_AttributeSet(field,name="FIELD_TYPE",         value=1,                    __RC__)
+      call ESMF_AttributeSet(field,name="REFRESH_INTERVAL",   value=0,                    __RC__)
+      call ESMF_AttributeSet(field,name="AVERAGING_INTERVAL", value=0,                    __RC__)
+
+      call MAPL_FieldBundleAdd ( bundle, field, __RC__ )
 
       return
 
@@ -493,12 +505,17 @@
 !EOP
 !------------------------------------------------------------------------------
 !BOC
-      field = ESMF_FieldCreate(grid=grid, fArrayptr=PTR, &
-              name = fieldName, RC=STATUS )
-      VERIFY_(STATUS)
+      field = ESMF_FieldCreate(grid=grid, fArrayptr=PTR, name=fieldName, __RC__ )
 
-      call MAPL_FieldBundleAdd ( bundle, field, rc=STATUS )
-      VERIFY_(STATUS)
+      call ESMF_AttributeSet(field,name="DIMS",                value=MAPL_DimsHorzOnly,  __RC__)
+      call ESMF_AttributeSet(field,name="VLOCATION",           value=MAPL_VLocationNone, __RC__)
+      call ESMF_AttributeSet(field,name="UNITS",               value="NA",               __RC__)
+      call ESMF_AttributeSet(field,name="LONG_NAME",           value="NA",               __RC__)
+      call ESMF_AttributeSet(field,name="FIELD_TYPE",          value=1,                  __RC__)
+      call ESMF_AttributeSet(field,name="REFRESH_INTERVAL",    value=0,                  __RC__)
+      call ESMF_AttributeSet(field,name="AVERAGING_INTERVAL",  value=0,                  __RC__)
+
+      call MAPL_FieldBundleAdd ( bundle, field, __RC__ )
 
       return
 
@@ -530,12 +547,17 @@
 !EOP
 !------------------------------------------------------------------------------
 !BOC
-      field = ESMF_FieldCreate(grid=grid, fArrayptr=PTR, &
-              name = fieldName, RC=STATUS )
-      VERIFY_(STATUS)
+      field = ESMF_FieldCreate(grid=grid, fArrayptr=PTR, name=fieldName, __RC__ )
 
-      call MAPL_FieldBundleAdd ( bundle, field, rc=STATUS )
-      VERIFY_(STATUS)
+      call ESMF_AttributeSet(field,name="DIMS",               value=MAPL_DimsHorzOnly,  __RC__)
+      call ESMF_AttributeSet(field,name="VLOCATION",          value=MAPL_VLocationNone, __RC__)
+      call ESMF_AttributeSet(field,name="UNITS",              value="NA",               __RC__)
+      call ESMF_AttributeSet(field,name="LONG_NAME",          value="NA",               __RC__)
+      call ESMF_AttributeSet(field,name="FIELD_TYPE",         value=1,                  __RC__)
+      call ESMF_AttributeSet(field,name="REFRESH_INTERVAL",   value=0,                  __RC__)
+      call ESMF_AttributeSet(field,name="AVERAGING_INTERVAL", value=0,                  __RC__)
+
+      call MAPL_FieldBundleAdd ( bundle, field, __RC__ )
 
       return
 

--- a/GMI_GridComp/GmiShared/GmiInclude/GmiParameters.h
+++ b/GMI_GridComp/GmiShared/GmiInclude/GmiParameters.h
@@ -83,16 +83,17 @@
 
       integer, parameter :: MAX_COL_DIAG_PRES  =   50 ! maximum number of pressures for column
                                                       ! diagnostic output
-      integer, parameter :: MAX_COL_DIAG_SITES = 300 ! maximum number of column diagnostic sites
+      integer, parameter :: MAX_COL_DIAG_SITES =  300 ! maximum number of column diagnostic sites
       integer, parameter :: MAX_INFILE_NAMES   = 1826 ! maximum number of input file names
       integer, parameter :: MAX_NUM_CONST_GIO  =  185 ! maximum number of const gen. I/O species
       integer, parameter :: MAX_NUM_QJ         =  200 ! maximum number of qj (photolysis) rxns
       integer, parameter :: MAX_NUM_QK         =  500 ! maximum number of qk (thermal)    rxns
 
-      integer, parameter :: num_AerDust        = 20   ! Number of entries for aerosol/dust 
-                                                      ! diagnostics
-      integer, parameter :: num_CM_AerDust     =  5   ! Number of column mass entries for 
-                                                      ! aerosol/dust diagnostics
+      integer, parameter :: num_AerDust = 3 + 2 + 3*nSADaer ! Number of entries needed for
+                                                            !  aerosol photolysis diagnostics
+                                                            !  = 3 + 2 + 3*nSADaer
+      integer, parameter :: num_CM_AerDust     =    5       ! Number of column mass entries for 
+                                                            ! aerosol/dust diagnostics
 
       integer, parameter :: MAX_STRING_LENGTH = MAX_LENGTH_SPECIES_NAME*MAX_COL_DIAG_SITES
 

--- a/GMI_GridComp/GmiShared/GmiInclude/gmi_sad_constants.h
+++ b/GMI_GridComp/GmiShared/GmiInclude/gmi_sad_constants.h
@@ -17,11 +17,23 @@
 !
 !=============================================================================
 
-
+! Indices for NSAD  (value in setkin_par.h):
       integer, parameter ::  &
-     &  ILBSSAD  = 1,    & ! index for liquid binary sulfate       SADs
-     &  ISTSSAD  = 2,    & ! index for supercooled ternary sulfate SADs
-     &  INATSAD  = 3,    & ! index for "NAT" SADs
-     &  IICESAD  = 4,    & ! index for ice   SADs
-     &  ISOOTSAD = 5   ! index for soot  SADs
+        ILBSSAD  = 1,        & ! index for liquid binary sulfate       SADs
+        ISTSSAD  = 2,        & ! index for supercooled ternary sulfate SADs
+        INATSAD  = 3,        & ! index for "NAT" SADs
+        IICESAD  = 4,        & ! index for ice   SADs
+        ISOOTSAD = 5           ! index for soot  SADs
+
+! Indices for NSADdust  (value in setkin_par.h):
+!  ????
+
+! Indices for NSADaer   (value in setkin_par.h):
+      integer, parameter ::  &
+        ISO4SAD   = 1,       & ! index for sulfate           SADs
+        IBCSAD    = 2,       & ! index for black carbon      SADs
+        IOCSAD    = 3,       & ! index for organic carbon    SADs
+        ISSaccSAD = 4,       & ! index for sea salt (accum)  SADs
+        ISScrsSAD = 5,       & ! index for sea salt (coarse) SADs
+        ISO4vSAD  = 6          ! index for volcanic sulfate  SADs
 

--- a/GMI_GridComp/GmiShared/GmiSupportingModules/GmiSpeciesRegistry_mod.F90
+++ b/GMI_GridComp/GmiShared/GmiSupportingModules/GmiSpeciesRegistry_mod.F90
@@ -11,9 +11,9 @@
  public  :: set_molWeightSpecies, get_molWeightSpecies
  public  :: UNKNOWN_SPECIES
 
-# include "GmiParameters.h"
-!# include "setkin_par.h"
+# include "setkin_par.h"
 !# include "setkin_lchem.h"
+# include "GmiParameters.h"
 
  integer, parameter :: UNKNOWN_SPECIES         = -2
 

--- a/GMI_GridComp/GmiShared/GmiSupportingModules/GmiStringManipulation_mod.F90
+++ b/GMI_GridComp/GmiShared/GmiSupportingModules/GmiStringManipulation_mod.F90
@@ -11,6 +11,7 @@
 !
       implicit none
 !
+#     include "setkin_par.h"
 #     include "GmiParameters.h"
 !
 ! !PUBLIC MEMBER FUNCTIONS:

--- a/GMI_GridComp/GmiSpeciesConcentration/spcConcentrationMethod/GmiSpcConcentrationMethod_mod.F90
+++ b/GMI_GridComp/GmiSpeciesConcentration/spcConcentrationMethod/GmiSpcConcentrationMethod_mod.F90
@@ -49,9 +49,9 @@
   integer          :: numMoleFrac
   integer          :: numChem
 
-#     include "GmiParameters.h"
 #     include "setkin_par.h"
 #     include "setkin_lchem.h"
+#     include "GmiParameters.h"
 
   type t_SpeciesConcentration
 !    private

--- a/GMI_GridComp/GmiSwapSpeciesBundlesMod.F90
+++ b/GMI_GridComp/GmiSwapSpeciesBundlesMod.F90
@@ -21,6 +21,7 @@ module GmiSwapSpeciesBundlesMod
       public  :: SwapSpeciesBundles
       public  :: speciesReg_for_CCM
 
+#include "setkin_par.h"
 #include "GmiParameters.h"
 #include "gmi_phys_constants.h"
 !

--- a/GMIchem_GridCompMod.F90
+++ b/GMIchem_GridCompMod.F90
@@ -330,7 +330,35 @@ CONTAINS
 
      CASE("CARMA")
 
-      STATUS = 0
+!   This is for CARMA SO4 surface area
+       CALL MAPL_AddImportSpec(GC,  &
+              SHORT_NAME         = 'SO4SAREA',  &
+              LONG_NAME          = 'SO4 aerosol surface area (non-Volcanic)',  &
+              UNITS              = 'm2 m-3', &
+              DIMS               = MAPL_DimsHorzVert,    &
+              VLOCATION          = MAPL_VLocationCenter,    &
+                                                        RC=STATUS  )
+       VERIFY_(STATUS)
+
+       CALL MAPL_AddImportSpec(GC,  &
+              SHORT_NAME         = 'SO4REFF',  &
+              LONG_NAME          = 'SO4 aerosol effective radius (non-Volcanic)',  &
+              UNITS              = 'm', &
+              DIMS               = MAPL_DimsHorzVert,    &
+              VLOCATION          = MAPL_VLocationCenter,    &
+                                                        RC=STATUS  )
+       VERIFY_(STATUS)
+
+!       CALL MAPL_AddImportSpec(GC,  &
+!              SHORT_NAME         = 'SO4SAREAvolc',  &
+!              LONG_NAME          = 'SO4 aerosol surface area (Volcanic)',  &
+!              UNITS              = 'm2 m-3', &
+!              DIMS               = MAPL_DimsHorzVert,    &
+!              VLOCATION          = MAPL_VLocationCenter,    &
+!                                                        RC=STATUS  )
+!       VERIFY_(STATUS)
+
+       IF(MAPL_AM_I_ROOT()) PRINT *,"  using CARMA SO4SAREA and SO4Reff"
 
 
      CASE("none")
@@ -380,7 +408,7 @@ CONTAINS
                                             Label="do_ShipEmission:", __RC__)
 
     IF ( do_ShipEmission ) THEN
-       call MAPL_AddImportSpec(GC,                         & 
+       call MAPL_AddImportSpec(GC,                         &
           SHORT_NAME = 'SHIP_NO',                          &
           LONG_NAME  = 'NO from Ships',                    &
           UNITS      = 'kg NO m^(-2) s^(-1)',              &
@@ -414,14 +442,14 @@ CONTAINS
 
 ! Future option - import OCS from ACHEM -  if (state%chemReg%doing_OCS) then import ACHEM::OCS
 
-     call MAPL_AddImportSpec(GC,                           & 
+     call MAPL_AddImportSpec(GC,                           &
         SHORT_NAME = 'OCS_CLIMO',                          &
         LONG_NAME  = 'Carbonyl Sulfide (OCS gas)',         &
         UNITS      = 'mol mol-1',                          &
         DIMS       = MAPL_DimsHorzVert,                    &
         VLOCATION  = MAPL_VLocationCenter,   __RC__) 
 
-     call MAPL_AddImportSpec(GC,                           & 
+     call MAPL_AddImportSpec(GC,                           &
         SHORT_NAME = 'CNV_FRC',                            &
         LONG_NAME  = 'convective_fraction',                &
         UNITS      = '',                                   &
@@ -1216,7 +1244,8 @@ CONTAINS
    If (ESMF_UtilStringLowerCase(trim(ProviderName)).eq.'none') ProviderName = 'none'
 
    gcGMI%gcPhot%aeroProviderName = TRIM(ProviderName)
-   IF(TRIM(providerName) == "GMICHEM" .or. TRIM(providerName) == "CARMA") THEN
+   IF(TRIM(providerName) == "GMICHEM") THEN
+!.sds   IF(TRIM(providerName) == "GMICHEM" .or. TRIM(providerName) == "CARMA") THEN
     gcGMI%gcPhot%AM_I_AERO_PROVIDER = .TRUE.
    ELSE
     gcGMI%gcPhot%AM_I_AERO_PROVIDER = .FALSE.
@@ -1307,7 +1336,7 @@ CONTAINS
                              RC=STATUS )
       VERIFY_(STATUS)
 
-!     IF(MAPL_AM_I_ROOT()) print*,'GMI species SHORT NAME '//TRIM(short_name)
+!     IF(MAPL_AM_I_ROOT()) print*,'GMI bgg species SHORT NAME '//TRIM(short_name)
 
       ! get the GMI REG pointers
       CALL MAPL_GetPointer ( internal, NAME=short_name, ptr=bgg%qa(L)%data3d, &
@@ -1333,7 +1362,7 @@ CONTAINS
                              RC=STATUS )
       VERIFY_(STATUS)
 
-!     IF(MAPL_AM_I_ROOT()) print*,'GMI species SHORT NAME '//TRIM(short_name)
+!     IF(MAPL_AM_I_ROOT()) print*,'GMI bxx species SHORT NAME '//TRIM(short_name)
 
       ! get the XX REG pointers
       CALL MAPL_GetPointer ( internal, NAME=short_name, ptr=bxx%qa(L)%data3d, &
@@ -1528,6 +1557,8 @@ CONTAINS
     CALL ESMF_AttributeSet(aero, NAME='implements_aerosol_optics_method', VALUE=.TRUE., __RC__)
     aeroBundle = ESMF_FieldBundleCreate(NAME='AEROSOLS', __RC__)
     CALL MAPL_StateAdd(aero, aeroBundle, __RC__)
+!.sds.. added for v11.0.0
+    CALL ESMF_AttributeSet(aero, NAME='number_of_aerosol_modes', VALUE=numAeroes, __RC__)
 
     DO n = 1,numAeroes
      CALL MAPL_GetPointer(expChem, PTR3D, TRIM(aeroName(n)), ALLOC=.TRUE., RC=STATUS)
@@ -2074,6 +2105,29 @@ CONTAINS
    gcGMI%gcEmiss%doingPredictorNow = doingPredictorNow
 
 
+!... if H2SO4 exists in GMI then ZERO OUT H2SO4;
+!... in the future the aerosol module may change H2SO4, making this step redundant
+   H2SO4LOSS: IF ( phase == 2 .OR. phase == 99 ) THEN
+     m = 1
+     n = ggReg%nq
+     iH2SO4 = -1
+     DO i = m,n
+       IF (TRIM(ggReg%vname(i)) == "H2SO4") THEN
+         iH2SO4 = i
+         EXIT
+       ENDIF
+     ENDDO
+!
+     IF(iH2SO4 >= 1) THEN
+       call ESMF_ConfigGetAttribute(CF, H2SO4_Source, LABEL="SULFURIC_ACID_SOURCE:", DEFAULT='GMIvalue', __RC__)
+        if(MAPL_AM_I_ROOT()) print '(''SULFURIC_ACID_SOURCE: '', a75)', trim(H2SO4_Source)
+        if (H2SO4_Source(1:10).ne."full_field") then
+          if(MAPL_AM_I_ROOT()) print '(''Setting H2SO4=1e-30 before GMICHEM: '', a75)', trim(H2SO4_Source)
+          bgg%qa(iH2SO4)%data3d(:,:,:) = 1e-30
+       endif
+     ENDIF
+   ENDIF H2SO4LOSS
+!...
 
 ! At the Heartbeat do Run 1
 ! -------------------------
@@ -2155,25 +2209,6 @@ CONTAINS
      ! Also compute OVP fields - see below
 
    END IF Phase99
-
-!... if H2SO4 exists in GMI then ZERO OUT H2SO4 unless coupled into SO4 altering aerosol component
-   H2SO4LOSS: IF ( phase == 2 .OR. phase == 99 ) THEN
-     m = 1
-     n = ggReg%nq
-     iH2SO4 = -1
-     DO i = m,n
-       IF (TRIM(ggReg%vname(i)) == "H2SO4") THEN
-         iH2SO4 = i
-         EXIT
-       ENDIF
-     ENDDO
-!... 
-     IF(iH2SO4 >= 1) THEN
-       call ESMF_ConfigGetAttribute(CF, H2SO4_Source, LABEL="SULFURIC_ACID_SOURCE:", DEFAULT='tendency', __RC__)
-       if (trim(H2SO4_Source).ne."full_field") bgg%qa(iH2SO4)%data3d(:,:,:) = 1e-30
-     ENDIF
-   ENDIF H2SO4LOSS
-
 
 !  Update age-of-air.
 !  This transported species is at bgg%qa(1)%data3d.


### PR DESCRIPTION
Captured all edits done for the 2024 Hunga experiments; this includes adding SO4v, using sulfate SAD and EffRadius from the AERO state, and a new SAD LBS option (5).  This PR is zero-diff when none of the new features are used.