### PR TITLE
Fixed GMITTO3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a memory leak in GmiSAD
+- Fixed the diagnostic GMITTO3
 
 ### Added
+
 - Added a reference for lightning NOx emissions files in ExtData yaml file; uncomment to use this option.
 - Added pyroCb chemistry mechanism as new choice (e.g., parallel_build.csh -mil -gmi_mechanism StratTrop_HFC_S_Pyro
 - Added coupling of GOCART provided SU and BR surface area density and effective radius to chemistry through aerosol state

--- a/GMIchem_GridCompMod.F90
+++ b/GMIchem_GridCompMod.F90
@@ -2171,7 +2171,7 @@ CONTAINS
        IF(ASSOCIATED( TO3)) TO3 = TO3+wrk
 
        IF(ASSOCIATED(TTO3)) THEN
-        wgt  = MAX(0.0,MIN(1.0,(PLE(:,:,k)-bgg%qa(iT2M)%data3d(:,:,km))/(PLE(:,:,k)-PLE(:,:,k-1))))
+        wgt  = MAX(0.0,MIN(1.0,(PLE(:,:,k)-bxx%qa(iT2M)%data3d(:,:,km))/(PLE(:,:,k)-PLE(:,:,k-1))))
         TTO3 = TTO3+wrk*wgt
        END IF
 


### PR DESCRIPTION
Simple bug fix, just involved the diagnostic; bug had been introduced when we changed from w_c to bgg and bxx; bug made GMITTO3 (tropospheric O3) to look exactly like GMITO3 (total O3).
All output besides GMITTO3 are zero-diff.